### PR TITLE
Add options that control optimization for nvcc - linux

### DIFF
--- a/MATLAB/mex_CUDA_glnxa64.xml
+++ b/MATLAB/mex_CUDA_glnxa64.xml
@@ -34,7 +34,7 @@
           NVCCFLAGS="-gencode=arch=compute_30,code=sm_30   -gencode=arch=compute_35,code=sm_35  -gencode=arch=compute_50,code=sm_50   -gencode=arch=compute_60,code=sm_60   -gencode=arch=compute_61,code=sm_61 --default-stream per-thread  $NVCC_FLAGS"
           CXXFLAGS="--compiler-options=-ansi,-fexceptions,-fPIC,-fno-omit-frame-pointer,-pthread"
           INCLUDE="-I&quot;$MATLABROOT/extern/include&quot; -I&quot;$MATLABROOT/simulink/include&quot; -I&quot;$MATLABROOT/toolbox/distcomp/gpu/extern/include/&quot;" 
-          CXXOPTIMFLAGS="-O -DNDEBUG"
+          CXXOPTIMFLAGS="-O3 -DNDEBUG"
           CXXDEBUGFLAGS="-g"
           
           LDXX="$GCC"


### PR DESCRIPTION
I had this error:

![Tmp](https://user-images.githubusercontent.com/29632934/66042193-3392fb80-e4f2-11e9-9786-946f191391fb.png)

Then added the optimization flag for nvcc/gcc, based on these links: [1](http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Optimize-Options.html#Optimize-Options) and [2](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-altering-compiler-linker-behavior-optimize)

Finally, I was able to compile everything:

![tmp2](https://user-images.githubusercontent.com/29632934/66042483-ed8a6780-e4f2-11e9-8698-c53f2c3155de.png)

My system configuration is:

- Ubuntu 19.04
- CUDA 10.1
- gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0
- MATLAB 2018a
