### PR TITLE
Add Wang weights for offset detector scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ Python/tigre/Source/_tvdenoising.cpp
 # Debug files
 *.dSYM/
 *.mexa64
+
+MATLAB/mex_CUDA_win64.xml

--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -18,12 +18,12 @@ function [res]=FDK(proj,geo,angles,varargin)
 %
 % Contact:            tigre.toolbox@gmail.com
 % Codes:              https://github.com/CERN/TIGRE/
-% Coded by:           Kyungsang Kim, modified by Ander Biguri 
+% Coded by:           Kyungsang Kim, modified by Ander Biguri, Brandon Nelson 
 %--------------------------------------------------------------------------
 [filter,parker]=parse_inputs(proj,geo,angles,varargin);
 
-if abs(geo.offDetector(1)) > 0
-    proj = apply_wang_weights(proj, geo);
+if apply_wang_weights(geo)
+    proj = wang_displaced_detector_weighting(proj, geo);
 end
 
 geo=checkGeo(geo,angles);
@@ -123,13 +123,12 @@ end
 
 end
 
-function proj = apply_wang_weights(proj, geo)
-
+function proj = wang_displaced_detector_weighting(proj, geo)
     overlap_in_mm = geo.sDetector(1)/2 - abs(geo.offDetector(1));
     overlap_in_pix = round(overlap_in_mm / geo.dDetector(1));
 
     t_in_mm = linspace(-overlap_in_mm, overlap_in_mm, 2 * overlap_in_pix);
-    R_in_mm = geo.DSO;
+    R_in_mm = geo.DSO(1);
     w = 0.5 * (sin((pi * atan(t_in_mm / R_in_mm)) / (2 * atan(overlap_in_mm / R_in_mm))) + 1);
     w = repmat(w, [geo.nDetector(1), 1, size(proj, 3)]);
 
@@ -140,4 +139,28 @@ function proj = apply_wang_weights(proj, geo)
     end
     wang_weights = 2 * wang_weights;
     proj = proj .* wang_weights;
+end
+
+function bool = apply_wang_weights(geo)
+    if size(geo.offDetector,2) > 1
+        bool = false;
+        return
+    end
+    
+    if geo.offDetector(1) == 0
+        bool = false;
+        return
+    end
+    
+    if numel(geo.DSO) > 1
+        bool = false;
+        return
+    end
+
+    percent_offset = abs(geo.offDetector(1)/geo.sDetector(1)) * 100;    
+    if percent_offset > 30
+        warning("Detector offset percent: %0.2f) is greater than 30 which may result in image artifacts, consider rebinning 360 degree projections to 180 degrees", percent_offset)
+    end
+    
+    bool = true;
 end

--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -142,7 +142,8 @@ function proj = wang_displaced_detector_weighting(proj, geo)
 end
 
 function bool = apply_wang_weights(geo)
-    if size(geo.offDetector,2) > 1
+    if (size(geo.offDetector,2) > 1) && length(unique(geo.offDetector(1,:)))>1
+        warning('FDK Wang weights: varying offDetector detected, Wang weigths not being applied');
         bool = false;
         return
     end
@@ -152,14 +153,15 @@ function bool = apply_wang_weights(geo)
         return
     end
     
-    if numel(geo.DSO) > 1
+    if (numel(geo.DSO) > 1) && (length(unique(geo.DSO))>1)
+        warning('FDK Wang weights: varying DSO detected, Wang weigths not being applied');
         bool = false;
         return
     end
 
     percent_offset = abs(geo.offDetector(1)/geo.sDetector(1)) * 100;    
     if percent_offset > 30
-        warning("Detector offset percent: %0.2f) is greater than 30 which may result in image artifacts, consider rebinning 360 degree projections to 180 degrees", percent_offset)
+        warning('FDK Wang weights: Detector offset percent: %0.2f) is greater than 30 which may result in image artifacts, consider rebinning 360 degree projections to 180 degrees', percent_offset)
     end
     
     bool = true;


### PR DESCRIPTION
Hello Ander,

I saw this originally from issue [# 151](https://github.com/CERN/TIGRE/issues/151)  and thought I would try implementing [Ge Wang's paper](https://aapm.onlinelibrary.wiley.com/doi/epdf/10.1118/1.1489043). The following works with my projection data as well as with simulations from the demo data in d14_Offsets.m.  You mentioned in your comments to #151 that this issue is specific to FDK so I think this added control flow should be sufficient. This is my first time contributing to this project and I'm to work with you if any thing needs to be changed to better fit the project  workflow.

Other notes:
Similar to the original paper, the following works for up to 30% offset, beyond that I get some shading in the center. It's likely pixel re-binning may be necessary for offsets between 30% and the max 50%.