### PR TITLE
Eliminated potential double-free

### DIFF
--- a/MATLAB/Source/Siddon_projection.cu
+++ b/MATLAB/Source/Siddon_projection.cu
@@ -297,27 +297,17 @@ int siddon_ray_projection(float  *  img, Geometry geo, float** result,float cons
     size_t mem_proj=                  (unsigned long long)geo.nDetecU*(unsigned long long)geo.nDetecV*sizeof(float);
     
     // Does everything fit in the GPUs?
-    bool fits_in_memory=false;
+    const bool fits_in_memory = mem_image+2*PROJ_PER_BLOCK*mem_proj<mem_GPU_global;
     unsigned int splits=1;
-    Geometry * geoArray;
-    
-    
-    if (mem_image+2*PROJ_PER_BLOCK*mem_proj<mem_GPU_global){// yes it does
-        fits_in_memory=true;
-        geoArray=(Geometry*)malloc(sizeof(Geometry));
-        geoArray[0]=geo;
-    }
-    else{// Nope nope.
-        fits_in_memory=false; // Oh dear.
+    if (!fits_in_memory) {
+        // Nope nope.
         // approx free memory we have. We already have left some extra 5% free for internal stuff
         // we need a second projection memory to combine multi-GPU stuff.
         size_t mem_free=mem_GPU_global-4*PROJ_PER_BLOCK*mem_proj;
-        
-        
         splits=mem_image/mem_free+1;// Ceil of the truncation
-        geoArray=(Geometry*)malloc(splits*sizeof(Geometry));
-        splitImage(splits,geo,geoArray,nangles);
     }
+    Geometry* geoArray = (Geometry*)malloc(splits*sizeof(Geometry));
+    splitImage(splits,geo,geoArray,nangles);
     
     // Allocate axuiliary memory for projections on the GPU to accumulate partial results
     float ** dProjection_accum;

--- a/MATLAB/Source/ray_interpolated_projection.cu
+++ b/MATLAB/Source/ray_interpolated_projection.cu
@@ -244,27 +244,17 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     size_t mem_proj =(unsigned long long)geo.nDetecU*(unsigned long long)geo.nDetecV * sizeof(float);
     
     // Does everything fit in the GPUs?
-    bool fits_in_memory=false;
+    const bool fits_in_memory = mem_image+2*PROJ_PER_BLOCK*mem_proj<mem_GPU_global;
     unsigned int splits=1;
-    Geometry * geoArray;
-    
-    
-    if (mem_image+2*PROJ_PER_BLOCK*mem_proj<mem_GPU_global){// yes it does
-        fits_in_memory=true;
-        geoArray=(Geometry*)malloc(sizeof(Geometry));
-        geoArray[0]=geo;
-    }
-    else{// Nope nope.
-        fits_in_memory=false; // Oh dear.
-        // approx free memory we have. We already have left some extra 10% free for internal stuff
+    if (!fits_in_memory) {
+        // Nope nope.
+        // approx free memory we have. We already have left some extra 5% free for internal stuff
         // we need a second projection memory to combine multi-GPU stuff.
         size_t mem_free=mem_GPU_global-4*PROJ_PER_BLOCK*mem_proj;
-        
-        
         splits=mem_image/mem_free+1;// Ceil of the truncation
-        geoArray=(Geometry*)malloc(splits*sizeof(Geometry));
-        splitImageInterp(splits,geo,geoArray,nangles);
     }
+    Geometry* geoArray = (Geometry*)malloc(splits*sizeof(Geometry));
+    splitImageInterp(splits,geo,geoArray,nangles);
     
     // Allocate auiliary memory for projections on the GPU to accumulate partial resutsl
     float ** dProjection_accum;


### PR DESCRIPTION
## Summary
I found code that has potential double free. This can be a problem in the migration from MATLAB to Python. I propose a solution.

## Background
 * I am preparing a PR for #152.
 * This modification is necessary for Python, but it seems that the problem stems from the original MATLAB code.

## Details
 * Although geoArray[i].offOrigZ was allocated if splits>1 and not if splits==1, freeGeoArray was always freeing it.
 * As a result, offOrigZ of geo that was passed by Ax_mex.cpp is freeed by freeGeoArray if splits == 1, and not freeed if splits>0.
     * This is not an issue in MATLAB code because Ax_mex.cpp does not free geo.offOrigZ.
     * but it is an issue in Python code because free_c_geometry of _types.pxd frees geo.offOrigZ and it causes double free if splits==1.

## Discussion
 * There could be several solutions:
     1. Modify to always allocate geoArray[i].offOrigZ. (This PR)
         * Pros: There was similar part in voxel_backprojection.cu.
         * Cons: Waste of memory (but its only 4 x nangles bytes)
     2. Remove free(geoArray[i].offOrigZ) from free_c_geometry
         * Pros: No modification necessary in MATLAB code.
         * Cons: The life of memory is different depending on conditions.
     3. Add more code to Geometry class to manage the memory by itself
         * Pros: Readability for some of developers
         * Cons: Affects all existing cpp and cu files.

## Test
### Raw Ax
```
clear;
close all;
geo=defaultGeometry('nVoxel',[128;128;128]*2);     
angles=linspace(0,2*pi,100);
head=headPhantom(geo.nVoxel);

projections=Ax(head,geo,angles,'interpolated');
plotProj(projections,angles)

projections=Ax(head,geo,angles,'ray-voxel');
plotProj(projections,angles)
```
In the most of the environment, the splits will be 1.
In order to check the case of splits>1, I modified a constant in checkFreeMemory from 0.95 to 0.01 and recompiled TIGRE.
(I also added a printf to check the value of splits.)

 * Both in the case of splits ==1 and splits == 2, it seemed OK.

### Reconstruction
 * d04_SimpleReconstruction.m
 * It seemed OK for splits ==1 and splits == 2.

### Environment
| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| GTX1060 |
