### PR TITLE
Fixed the device name check process

### DIFF
--- a/MATLAB/Source/POCS_TV.cu
+++ b/MATLAB/Source/POCS_TV.cu
@@ -269,19 +269,21 @@ do { \
         // 1.-All available devices are usable by this code
         // 2.-All available devices are equal, they are the same machine (warning trhown)
         int dev;
-        char * devicenames;
+        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+        char devicename[devicenamelength];
         cudaDeviceProp deviceProp;
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(dev);
             cudaGetDeviceProperties(&deviceProp, dev);
             if (dev>0){
-                if (strcmp(devicenames,deviceProp.name)!=0){
+                if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
                     break;
                 }
             }
-            devicenames=deviceProp.name;
+            memset(devicename, 0, devicenamelength);
+            strcpy(devicename, deviceProp.name);
         }
         
         

--- a/MATLAB/Source/POCS_TV2.cu
+++ b/MATLAB/Source/POCS_TV2.cu
@@ -290,19 +290,21 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
         // 1.-All available devices are usable by this code
         // 2.-All available devices are equal, they are the same machine (warning trhown)
         int dev;
-        char * devicenames;
+        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+        char devicename[devicenamelength];
         cudaDeviceProp deviceProp;
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(dev);
             cudaGetDeviceProperties(&deviceProp, dev);
             if (dev>0){
-                if (strcmp(devicenames,deviceProp.name)!=0){
+                if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
                     break;
                 }
             }
-            devicenames=deviceProp.name;
+            memset(devicename, 0, devicenamelength);
+            strcpy(devicename, deviceProp.name);
         }
         
         

--- a/MATLAB/Source/Siddon_projection.cu
+++ b/MATLAB/Source/Siddon_projection.cu
@@ -271,20 +271,22 @@ int siddon_ray_projection(float  *  img, Geometry geo, float** result,float cons
     // 1.-All available devices are usable by this code
     // 2.-All available devices are equal, they are the same machine (warning thrown)
     int dev;
-    char * devicenames;
+    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+    char devicename[devicenamelength];
     cudaDeviceProp deviceProp;
     
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(dev);
         cudaGetDeviceProperties(&deviceProp, dev);
         if (dev>0){
-            if (strcmp(devicenames,deviceProp.name)!=0){
+            if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
                 break;
             }
         }
-        devicenames=deviceProp.name;
-    }
+        memset(devicename, 0, devicenamelength);
+        strcpy(devicename, deviceProp.name);
+}
     
     
     

--- a/MATLAB/Source/ray_interpolated_projection.cu
+++ b/MATLAB/Source/ray_interpolated_projection.cu
@@ -221,20 +221,22 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     // 1.-All available devices are usable by this code
     // 2.-All available devices are equal, they are the same machine (warning trhown)
     int dev;
-    char * devicenames;
+    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+    char devicename[devicenamelength];
     cudaDeviceProp deviceProp;
     
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(dev);
         cudaGetDeviceProperties(&deviceProp, dev);
         if (dev>0){
-            if (strcmp(devicenames,deviceProp.name)!=0){
+            if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
                 break;
             }
         }
-        devicenames=deviceProp.name;
-    }
+        memset(devicename, 0, devicenamelength);
+        strcpy(devicename, deviceProp.name);
+}
     
     // Check free memory
     size_t mem_GPU_global;

--- a/MATLAB/Source/tvdenoising.cu
+++ b/MATLAB/Source/tvdenoising.cu
@@ -186,19 +186,21 @@ do { \
         // 1.-All available devices are usable by this code
         // 2.-All available devices are equal, they are the same machine (warning trhown)
         int dev;
-        char * devicenames;
+        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+        char devicename[devicenamelength];
         cudaDeviceProp deviceProp;
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(dev);
             cudaGetDeviceProperties(&deviceProp, dev);
             if (dev>0){
-                if (strcmp(devicenames,deviceProp.name)!=0){
+                if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
                     break;
                 }
             }
-            devicenames=deviceProp.name;
+            memset(devicename, 0, devicenamelength);
+            strcpy(devicename, deviceProp.name);
         }
         
         // We don't know if the devices are being used. lets check that. and only use the amount of memory we need.

--- a/MATLAB/Source/voxel_backprojection.cu
+++ b/MATLAB/Source/voxel_backprojection.cu
@@ -612,18 +612,20 @@ void checkDevices(void){
     int dev;
     int deviceCount = 0;
     cudaGetDeviceCount(&deviceCount);
-    char * devicenames;
+    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+    char devicename[devicenamelength];
     cudaDeviceProp deviceProp;
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(dev);
         cudaGetDeviceProperties(&deviceProp, dev);
         if (dev>0){
-            if (strcmp(devicenames,deviceProp.name)!=0){
+            if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Atb:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
                 break;
             }
         }
-        devicenames=deviceProp.name;
+        memset(devicename, 0, devicenamelength);
+        strcpy(devicename, deviceProp.name);
     }
 }
 void splitCTbackprojection(int deviceCount,Geometry geo,int nalpha, unsigned int* split_image, unsigned int * split_projections){

--- a/MATLAB/Source/voxel_backprojection2.cu
+++ b/MATLAB/Source/voxel_backprojection2.cu
@@ -686,18 +686,20 @@ void checkDevices(void){
     int dev;
     int deviceCount = 0;
     cudaGetDeviceCount(&deviceCount);
-    char * devicenames;
+    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+    char devicename[devicenamelength];
     cudaDeviceProp deviceProp;
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(dev);
         cudaGetDeviceProperties(&deviceProp, dev);
         if (dev>0){
-            if (strcmp(devicenames,deviceProp.name)!=0){
+            if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Atb:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
                 break;
             }
         }
-        devicenames=deviceProp.name;
+        memset(devicename, 0, devicenamelength);
+        strcpy(devicename, deviceProp.name);
     }
 }
 void splitCTbackprojection(int deviceCount,Geometry geo,int nalpha, unsigned int* split_image, unsigned int * split_projections){


### PR DESCRIPTION
## Expected
I have a machine with 3-GPUs:
|  id |   name |
|----|-------|
| 0 | RTX 2080 Ti |
| 1 | RTX 2080 Ti |
| 2 | GTX 1070 |

The code such as 
https://github.com/CERN/TIGRE/blob/d5bed315e5fac2353839fa5fa655c3906449df26/MATLAB/Source/voxel_backprojection.cu#L612-L627

looked to me that it is intended to output warnings at runtime on such machines as mine.

## Actual
 * d04_SimpleReconstruction.m
 * No warnings.

## Test
 * d04_SimpleReconstruction.m
 * Tested under 3 conditions as below
### 3-GPU machine (heterogeneous)
 * Plenty of warnings...
 * The reconstructed images are displayed.

| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| 2xRTX2080Ti, 1xGTX1070 |

### 2-GPU machine (homogeneous)
 * No Warning
 * The reconstructed images are displayed.

| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| 2xRTX2080Ti |
 * GTX1070 is disabled using the device manager.


### 1-GPU machine
 * No Warning
 * The reconstructed images are displayed.

| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| GTX1060 |

##
 * I am sorry if I misunderstood your intention.
