### PR TITLE
Eliminated access violation in Ax on 3-GPU machine

### DIFF
--- a/MATLAB/Source/ray_interpolated_projection.cu
+++ b/MATLAB/Source/ray_interpolated_projection.cu
@@ -236,7 +236,7 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
         }
         memset(devicename, 0, devicenamelength);
         strcpy(devicename, deviceProp.name);
-}
+    }
     
     // Check free memory
     size_t mem_GPU_global;
@@ -324,7 +324,7 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     int nangles_device=(nangles+deviceCount-1)/deviceCount;
     int nangles_last_device=(nangles-(deviceCount-1)*nangles_device);
     unsigned int noOfKernelCalls = (nangles_device+PROJ_PER_BLOCK-1)/PROJ_PER_BLOCK;  // We'll take care of bounds checking inside the loop if nalpha is not divisible by PROJ_PER_BLOCK
-    unsigned int last_device_blocks= (nangles_last_device+PROJ_PER_BLOCK-1)/PROJ_PER_BLOCK; // we will use this in the memory management.
+    unsigned int noOfKernelCallsLastDev = (nangles_last_device+PROJ_PER_BLOCK-1)/PROJ_PER_BLOCK; // we will use this in the memory management.
     int projection_this_block;
 
 
@@ -349,11 +349,10 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
         dim3 block(divU,divV,PROJ_PER_BLOCK);
         
         unsigned int proj_global;
-        unsigned int i;
         float maxdist;
         // Now that we have prepared the image (piece of image) and parameters for kernels
         // we project for all angles.
-        for ( i=0; i<noOfKernelCalls; i++){
+        for (unsigned int i=0; i<noOfKernelCalls; i++) {
             for (dev=0;dev<deviceCount;dev++){
                 float is_spherical=0;
                 cudaSetDevice(dev);
@@ -455,8 +454,23 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
                     cudaSetDevice(dev);
                     //Global index of FIRST projection on previous set on this GPU
                     proj_global=(i-1)*PROJ_PER_BLOCK+dev*nangles_device;
-                    //Unless it is the last (handled separately later), all blocks are full.
-                    projection_this_block=PROJ_PER_BLOCK;
+                    if (dev+1==deviceCount) {    //is it the last device?
+                        // projections assigned to this device is >=nangles_device-(deviceCount-1) and < nangles_device
+                        if (i-1 < noOfKernelCallsLastDev) {
+                            // The previous set(block) was not empty.
+                            projection_this_block=min(PROJ_PER_BLOCK, nangles-proj_global);
+                        }
+                        else {
+                            // The previous set was empty.
+                            // This happens if deviceCount > PROJ_PER_BLOCK+1.
+                            // e.g. PROJ_PER_BLOCK = 9, deviceCount = 11, nangles = 199.
+                            // e.g. PROJ_PER_BLOCK = 1, deviceCount =  3, nangles =   7.
+                            break;
+                        }
+                    }
+                    else {
+                        projection_this_block=PROJ_PER_BLOCK;
+                    }
                     cudaMemcpyAsync(result[proj_global], dProjection[(int)(!(i%2))+dev*2],  projection_this_block*geo.nDetecV*geo.nDetecU*sizeof(float), cudaMemcpyDeviceToHost,stream[dev*2+1]);
                 }
             }
@@ -468,8 +482,7 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
             }
         } // End noOfKernelCalls (i) loop.
         
-        // We still have the last set of projections to get out of all GPUs
-        //Note: noOfKernelCalls==i
+        // We still have the last set of projections to get out of GPUs
         for (dev = 0; dev < deviceCount; dev++)
         {
             cudaSetDevice(dev);


### PR DESCRIPTION
## Summary
Eliminated access violation when the number of angles is a specific value on multi-GPU machines to solve #132

## Details
Running the following script on a 3-GPU machine, when nangles = 28, 55, ..., MATLAB crashes.
```
clear;
close all;

sizeVol = 256;
geo=defaultGeometry('nVoxel',[sizeVol;sizeVol;sizeVol]);
head=ones(geo.nVoxel', 'single');
geo.mode='cone';

kMin = 1;
kMax = 100;

%% Ax, Cone, interpolated
disp('cone interpolated');
for k=kMin:kMax  % die at 28. Access Violation 
    disp(k);
    angles=linspace(0,2*pi, k);
    projections=Ax(head,geo,angles,'interpolated');
end    
disp('done');

%% Ax, Cone, ray-voxel
disp('cone ray-voxel');
for k=kMin:kMax  % die at 28. Access Violation 
    disp(k);
    angles=linspace(0,2*pi, k);
    projections=Ax(head,geo,angles,'ray-voxel');
end    
disp('done');

%% Check Projection image
nangles = 28;
angles=linspace(0,2*pi, nangles);
projections=Ax(head,geo,angles,'interpolated');
plotProj(projections,angles)

%% Reconstruct image using SART and FDK
nangles = 28;
angles=linspace(0,2*pi,nangles);
head=headPhantom(geo.nVoxel);
projections=Ax(head,geo,angles,'interpolated');
noise_projections=addCTnoise(projections);
% FDK
imgFDK=FDK(noise_projections,geo,angles);
% SART
niter=5;
imgSART=SART(noise_projections,geo,angles,niter);
% Show the results
plotImg([imgFDK,imgSART],'Dim','Z');

```

## Test
### Results

| Machine | GPUs |              | master | this PR |
|---------|------|--------------|-----|-----|
| A       | 1    | interpolated | OK  | OK  |
| A       | 1    | ray-voxel    | OK  | OK  |
| A       | 1    | demo/d04_S.. | OK  | OK  |
| B       | 3(*) | interpolated | NG  | OK  |
| B       | 3(*) | ray-voxel    | NG  | OK  |
| B       | 3(*) | demo/d04_S.. | OK  | OK  |

(*) The lines of code to check the device name are modified to skip.

### Coditions
 * Machine A
 
| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| GTX1060 |

 * Machine B
 
| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10 |
|**MATLAB**|  2016a |
|**CUDA**| 10.1|
|**Visual Studio**| 2015|
|**GPU**| 2xRTX2080, 1xGTX1070 |

## Discussion
 * On 3-GPU machine, this occurs when nangles = 28+3x9xN (N=0, 1, 2, ...)
 * On 4-GPU machine, this will occur in the following cases:
    1. nangles = 37+4x9xN (N=0, 1, 2, ...)
    2. nangles = 38+4x9xN (N=0, 1, 2, ...)
    3. nangles = 41+4x9xN (N=0, 1, 2, ...)
    * The conditions mentioned in https://github.com/CERN/TIGRE/issues/132#issuecomment-681130232 by @bnel1201 are included in case 1 and 2.
    * Not checked because I don't have access to 4-GPU machies.
 