### PR TITLE
Fixed MATLAB plotImg Dim3 X-label direction

### DIFF
--- a/MATLAB/Utilities/plotImg.m
+++ b/MATLAB/Utilities/plotImg.m
@@ -202,7 +202,7 @@ for ii=list
     
     if crossect==3 
         xlabel('->Y');
-        ylabel('X<-');
+        ylabel('->X');
         title(['Bottom to top->Z : ',num2str(ii)]);
     end
      if crossect==2 


### PR DESCRIPTION
## Expected Behavior

![plotImg_dim3](https://user-images.githubusercontent.com/25704789/98196041-809f9780-1f66-11eb-925c-a8a568fb5ba3.gif)


## Actual Behavior
 * The direction of the arrow indicating the X+ direction is opposite.
![plotImg_dim3_wrong](https://user-images.githubusercontent.com/25704789/98196043-81d0c480-1f66-11eb-8f8e-27cb46435e50.gif)

## Code to reproduce the problem (If applicable)

```
clear;
close all;
nangles=30
nXLen=256
nYLen=128
nZLen=64

geo=defaultGeometry('nVoxel',[nXLen;nYLen;nZLen]);                     
angles=linspace(0,2*pi-2*pi/nangles,nangles);
head=headPhantom(geo.nVoxel);

%% Draw 3 bars along axes from origin toward + directions.
head(int32(nXLen*2/4   : nXLen*3/4  ) ...
   , int32(nYLen*2/4-5 : nYLen*2/4+5) ...
   , int32(nZLen*2/4-5 : nZLen*2/4+5)) = 1;

head(int32(nXLen*2/4-5 : nXLen*2/4+5) ...
   , int32(nYLen*2/4   : nYLen*3/4  ) ...
   , int32(nZLen*2/4-5 : nZLen*2/4+5)) = 1;

head(int32(nXLen*2/4-5 : nXLen*2/4+5) ...
   , int32(nYLen*2/4-5 : nYLen*2/4+5) ...
   , int32(nZLen*2/4   : nZLen*3/4)) = 1;

%% 'X' label indicates wrong direction
plotImg(head, 'Dim', 3, 'Savegif', 'plotImg_dim3.gif', 'Step', 2)
%% OK
plotImg(head, 'Dim', 2, 'Savegif', 'plotImg_dim2.gif', 'Step', 2)
%% OK
plotImg(head, 'Dim', 1, 'Savegif', 'plotImg_dim1.gif', 'Step', 2)
```

## Specifications 

  - MATLAB version: 2016a
  - OS: Windows 10
  - CUDA version: 10.1

## Discussion
 * Other two directions were OK.
![plotImg_dim1](https://user-images.githubusercontent.com/25704789/98197396-f3f6d880-1f69-11eb-9ad9-0cd52682df7e.gif)
![plotImg_dim2](https://user-images.githubusercontent.com/25704789/98197399-f6593280-1f69-11eb-813b-aad264e847df.gif)

