### PR TITLE
Fix MATLAB Ax('Siddon') to use siddon_ray_projection

### DIFF
--- a/MATLAB/Source/Ax_mex.cpp
+++ b/MATLAB/Source/Ax_mex.cpp
@@ -85,7 +85,7 @@ void mexFunction(int  nlhs , mxArray *plhs[],
         mexErrMsgIdAndTxt( "CBCT:MEX:Ax:InvalidInput","4rd input shoudl be either 'interpolated' or 'Siddon'");
     else
         // If its not ray-voxel, its "interpolated"
-        if (!strcmp(krylov,"Siddon") == 0 || strcmp(krylov,"ray-voxel") == 0) //strcmp returs 0 if they are equal
+        if (strcmp(krylov,"Siddon") == 0 || strcmp(krylov,"ray-voxel") == 0) //strcmp returs 0 if they are equal
             rayvoxel=true;
     ///////////////////////// 3rd argument: angle of projection.
     


### PR DESCRIPTION
## Summary
 * MATLAB Ax('Siddon') were using interpolation_projection while Ax('ray-voxel') were using siddon_ray_projection due to #212.
 * Now both use siddon_ray_projection.

## Test code
https://github.com/CERN/TIGRE/blob/40aa20f107976c1fdfdbcafa40e6edb1d8ab90df/MATLAB/Source/Ax_mex.cpp#L304-L316
is modified as
```
    if (coneBeam){
        if (rayvoxel){
            printf("Calling siddon_ray_projection...");
            siddon_ray_projection(img,geo,result,angles,nangles);
        }else{
            printf("Calling interpolation_projection...");
            interpolation_projection(img,geo,result,angles,nangles);
        }
    }else{
        if (rayvoxel){
            printf("Calling siddon_ray_projection_parallel...");
            siddon_ray_projection_parallel(img,geo,result,angles,nangles);
        }else{
            printf("Calling interpolation_projection_parallel...");
            interpolation_projection_parallel(img,geo,result,angles,nangles);
        }
    }
```
Then,  all combination of ("cone"/"parallel") and ("ray-voxel", "Siddon", "interpolated") were run and checked the output text.

