### PR TITLE
Detector rotation in parallel mode

### DIFF
--- a/MATLAB/Source/Siddon_projection_parallel.cu
+++ b/MATLAB/Source/Siddon_projection_parallel.cu
@@ -395,7 +395,26 @@ void computeDeltas_Siddon_parallel(Geometry geo, float angles,int i, Point3D* uv
     Pv0.x=-(geo.DSD[i]-geo.DSO[i]);   Pv0.y= geo.dDetecU*(0-((float)geo.nDetecU/2)+0.5);       Pv0.z= geo.dDetecV*(((float)geo.nDetecV/2)-0.5-1);
     // Geomtric trasnformations:
     
-    //1: Offset detector
+    //1.Roll,pitch,jaw
+    // The detector can have a small rotation.
+    // according to
+    //"A geometric calibration method for cone beam CT systems" Yang K1, Kwan AL, Miller DF, Boone JM. Med Phys. 2006 Jun;33(6):1695-706.
+    // Only the Z rotation will have a big influence in the image quality when they are small.
+    // Still all rotations are supported
+    
+    // To roll pitch jaw, the detector has to be in centered in OXYZ.
+    P.x=0;Pu0.x=0;Pv0.x=0;
+    
+    // Roll pitch yaw
+    rollPitchYaw(geo,i,&P);
+    rollPitchYaw(geo,i,&Pu0);
+    rollPitchYaw(geo,i,&Pv0);
+    //Now ltes translate the points where they shoudl be:
+    P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
+    Pu0.x=Pu0.x-(geo.DSD[i]-geo.DSO[i]);
+    Pv0.x=Pv0.x-(geo.DSD[i]-geo.DSO[i]);
+    
+    //2: Offset detector
     
     //P.x
     P.y  =P.y  +geo.offDetecU[i];    P.z  =P.z  +geo.offDetecV[i];

--- a/MATLAB/Source/Siddon_projection_parallel.cu
+++ b/MATLAB/Source/Siddon_projection_parallel.cu
@@ -406,9 +406,9 @@ void computeDeltas_Siddon_parallel(Geometry geo, float angles,int i, Point3D* uv
     P.x=0;Pu0.x=0;Pv0.x=0;
     
     // Roll pitch yaw
-    rollPitchYaw(geo,i,&P);
-    rollPitchYaw(geo,i,&Pu0);
-    rollPitchYaw(geo,i,&Pv0);
+    rollPitchYaw_parallel(geo,i,&P);
+    rollPitchYaw_parallel(geo,i,&Pu0);
+    rollPitchYaw_parallel(geo,i,&Pv0);
     //Now ltes translate the points where they shoudl be:
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Pu0.x=Pu0.x-(geo.DSD[i]-geo.DSO[i]);
@@ -533,5 +533,23 @@ float maxDistanceCubeXY(Geometry geo, float angles,int i){
     return geo.DSO[i]/geo.dVoxelX-sqrt(maxCubX*maxCubX+maxCubY*maxCubY);
     
 }
-
+void rollPitchYaw_parallel(Geometry geo,int i, Point3D* point){
+    Point3D auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+    
+    point->x=cos(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
+            +(cos(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) - sin(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
+            +(cos(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) + sin(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.z;
+    
+    point->y=sin(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) + cos(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) - cos(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.z;
+    
+    point->z=-sin(geo.dPitch[i])*auxPoint.x
+            +cos(geo.dPitch[1])*sin(geo.dYaw[i])*auxPoint.y
+            +cos(geo.dPitch[1])*cos(geo.dYaw[i])*auxPoint.z;
+    
+}
 #endif

--- a/MATLAB/Source/Siddon_projection_parallel.hpp
+++ b/MATLAB/Source/Siddon_projection_parallel.hpp
@@ -54,7 +54,7 @@ Codes  : https://github.com/CERN/TIGRE
 #ifndef PROJECTION_PARALLEL_HPP_SIDDON
 #define PROJECTION_PARALLEL_HPP_SIDDON
 int siddon_ray_projection_parallel(float  *  img, Geometry geo, float** result,float const * const alphas,int nalpha);
-
+void rollPitchYaw_parallel(Geometry geo,unsigned int i, Point3D* point);
 //double computeMaxLength(Geometry geo, double alpha);
 void computeDeltas_Siddon_parallel(Geometry geo, float alpha,int i, Point3D* uvorigin, Point3D* deltaU, Point3D* deltaV, Point3D* source);
 

--- a/MATLAB/Source/ray_interpolated_projection_parallel.cu
+++ b/MATLAB/Source/ray_interpolated_projection_parallel.cu
@@ -324,7 +324,18 @@ void computeDeltas_parallel(Geometry geo, float alpha,unsigned int i, Point3D* u
     Pv0.x=-(geo.DSD[i]-geo.DSO[i]);   Pv0.y= geo.dDetecU*(0-((float)geo.nDetecU/2)+0.5);       Pv0.z= geo.dDetecV*(((float)geo.nDetecV/2)-0.5-1);
     // Geomtric trasnformations:
     
-    //1: Offset detector
+    // To roll pitch yaw, the detector has to be centered in OXYZ.
+    P.x=0;Pu0.x=0;Pv0.x=0;
+    
+    //1. Roll pitch yaw
+    rollPitchYaw(geo,i,&P);
+    rollPitchYaw(geo,i,&Pu0);
+    rollPitchYaw(geo,i,&Pv0);
+    //Now ltes translate the detector coordinates to DOD (original position on real coordinate system:
+    P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
+    Pu0.x=Pu0.x-(geo.DSD[i]-geo.DSO[i]);
+    Pv0.x=Pv0.x-(geo.DSD[i]-geo.DSO[i]);
+    //2: Offset detector
     
     //P.x
     P.y  =P.y  +geo.offDetecU[i];    P.z  =P.z  +geo.offDetecV[i];

--- a/MATLAB/Source/ray_interpolated_projection_parallel.cu
+++ b/MATLAB/Source/ray_interpolated_projection_parallel.cu
@@ -328,9 +328,9 @@ void computeDeltas_parallel(Geometry geo, float alpha,unsigned int i, Point3D* u
     P.x=0;Pu0.x=0;Pv0.x=0;
     
     //1. Roll pitch yaw
-    rollPitchYaw(geo,i,&P);
-    rollPitchYaw(geo,i,&Pu0);
-    rollPitchYaw(geo,i,&Pv0);
+    rollPitchYaw_parallel(geo,i,&P);
+    rollPitchYaw_parallel(geo,i,&Pu0);
+    rollPitchYaw_parallel(geo,i,&Pv0);
     //Now ltes translate the detector coordinates to DOD (original position on real coordinate system:
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Pu0.x=Pu0.x-(geo.DSD[i]-geo.DSO[i]);
@@ -439,5 +439,24 @@ void CreateTextureParallelInterp(float* image,Geometry geo,cudaArray** d_cuArrTe
     texDescr.addressMode[2] = cudaAddressModeBorder;
     texDescr.readMode = cudaReadModeElementType;
     cudaCreateTextureObject(&texImage[0], &texRes, &texDescr, NULL);
+    
+}
+void rollPitchYaw_parallel(Geometry geo,unsigned int i, Point3D* point){
+    Point3D auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+    
+    point->x=cos(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
+            +(cos(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) - sin(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
+            +(cos(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) + sin(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.z;
+    
+    point->y=sin(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) + cos(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) - cos(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.z;
+    
+    point->z=-sin(geo.dPitch[i])*auxPoint.x
+            +cos(geo.dPitch[i])*sin(geo.dYaw[i])*auxPoint.y
+            +cos(geo.dPitch[i])*cos(geo.dYaw[i])*auxPoint.z;
     
 }

--- a/MATLAB/Source/ray_interpolated_projection_parallel.hpp
+++ b/MATLAB/Source/ray_interpolated_projection_parallel.hpp
@@ -57,7 +57,7 @@ Codes  : https://github.com/CERN/TIGRE
 int interpolation_projection_parallel(float  *  img, Geometry geo, float** result,float const * const alphas,int nalpha);
 // float computeMaxLength(Geometry geo, float alpha);
 void computeDeltas_parallel(Geometry geo, float alpha,unsigned int i, Point3D* uvorigin, Point3D* deltaU, Point3D* deltaV, Point3D* source);
-
+void rollPitchYaw_parallel(Geometry geo,unsigned int i, Point3D* point);
 // float maxDistanceCubeXY(Geometry geo, float alpha,int i);
 
 // below, not used

--- a/MATLAB/Source/voxel_backprojection_parallel.cu
+++ b/MATLAB/Source/voxel_backprojection_parallel.cu
@@ -533,10 +533,10 @@ void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D*
     Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
     Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
     Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
-    rollPitchYawT(geo,i,&P);
-    rollPitchYawT(geo,i,&Px);
-    rollPitchYawT(geo,i,&Py);
-    rollPitchYawT(geo,i,&Pz);
+    rollPitchYawT_parallel(geo,i,&P);
+    rollPitchYawT_parallel(geo,i,&Px);
+    rollPitchYawT_parallel(geo,i,&Py);
+    rollPitchYawT_parallel(geo,i,&Pz);
     
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
@@ -547,7 +547,7 @@ void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D*
     source.x=geo.DSO[i]; //allready offseted for rotation
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
-    rollPitchYawT(geo,i,&source);
+    rollPitchYawT_parallel(geo,i,&source);
     
     
     P.z =P.z /geo.dDetecV;                          P.y =P.y/geo.dDetecU;
@@ -605,5 +605,26 @@ void CreateTextureParallel(float* projectiondata,Geometry geo,cudaArray** d_cuAr
         texDescr.readMode = cudaReadModeElementType;
         cudaCreateTextureObject(&texImage[0], &texRes, &texDescr, NULL);
         cudaCheckErrors("Texture object creation fail");
+    
+}
+void rollPitchYawT_parallel(Geometry geo,int i, Point3D* point){
+    Point3D auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+    
+    point->x=cos(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
+            +sin(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.y
+            -sin(geo.dPitch[i])*auxPoint.z;
+    
+    
+    point->y=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) - sin(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.x
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) + cos(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
+            +cos(geo.dPitch[i])*sin(geo.dYaw[i])*auxPoint.z;
+    
+    
+    point->z=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) + sin(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.x
+            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) - cos(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.y
+            +cos(geo.dPitch[i])*cos(geo.dYaw[i])*auxPoint.z;
     
 }

--- a/MATLAB/Source/voxel_backprojection_parallel.cu
+++ b/MATLAB/Source/voxel_backprojection_parallel.cu
@@ -525,12 +525,30 @@ void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D*
     Pz.z =Pz.z-geo.offDetecV[i];          Pz.y =Pz.y-geo.offDetecU[i];
     
     //Detector Roll pitch Yaw
+    //
+    //
+    // first, we need to offset everything so (0,0,0) is the center of the detector
+    // Only X is required for that
+    P.x=P.x+(geo.DSD[i]-geo.DSO[i]);
+    Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
+    Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
+    Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
+    rollPitchYawT(geo,i,&P);
+    rollPitchYawT(geo,i,&Px);
+    rollPitchYawT(geo,i,&Py);
+    rollPitchYawT(geo,i,&Pz);
     
-    
+    P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
+    Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
+    Py.x=Py.x-(geo.DSD[i]-geo.DSO[i]);
+    Pz.x=Pz.x-(geo.DSD[i]-geo.DSO[i]);
+    //Done for P, now source
     Point3D source;
     source.x=geo.DSO[i]; //allready offseted for rotation
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
+    rollPitchYawT(geo,i,&source);
+    
     
     P.z =P.z /geo.dDetecV;                          P.y =P.y/geo.dDetecU;
     Px.z=Px.z/geo.dDetecV;                          Px.y=Px.y/geo.dDetecU;

--- a/MATLAB/Source/voxel_backprojection_parallel.hpp
+++ b/MATLAB/Source/voxel_backprojection_parallel.hpp
@@ -49,7 +49,7 @@ Codes  : https://github.com/CERN/TIGRE
 
 #ifndef BACKPROJECTION_PARALLEL_HPP
 #define BACKPROJECTION_PARALLEL_HPP
-
+void rollPitchYawT_parallel(Geometry geo,int i, Point3D* point);
 int  voxel_backprojection_parallel(float  *  projections, Geometry geo, float* result,float const * const alphas,int nalpha);
 void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D *S);
 void createGeoArrayParallel(unsigned int image_splits, Geometry geo,Geometry* geoArray, unsigned int nangles);


### PR DESCRIPTION
In response to issue #168, however these changes address Matlab version.
- detector rotation was added to parallel mode by adding the function rollPitchYaw_parallel to: ray_interpolated_projection_parallel.cu, Siddon_projection_parallel.cu, voxel_backprojection_parallel.cu.