### PR TITLE
Fix some discrepancies btw MATLAB/Python

### DIFF
--- a/MATLAB/Source/AwminTV.cpp
+++ b/MATLAB/Source/AwminTV.cpp
@@ -90,22 +90,24 @@ void mexFunction(int  nlhs , mxArray *plhs[],
     // First input should be x from (Ax=b), or the image.
     mxArray const * const image = prhs[0];
     mwSize const numDims = mxGetNumberOfDimensions(image);
+    mwSize third_dim = 1;
     
-    // Image should be dim 3
-    if (numDims!=3){
-        mexErrMsgIdAndTxt("err", "Image is not 3D");
-    }
     // Now that input is ok, parse it to C data types.
     float  *  img = static_cast<float  *>(mxGetData(image));
     const mwSize *size_img= mxGetDimensions(image); //get size of image
 
+    // Image should be dim 3
+    if (numDims==3){
+        third_dim = size_img[2];
+    }
     
     // Allocte output image
-    plhs[0] = mxCreateNumericArray(3,size_img, mxSINGLE_CLASS, mxREAL);
+    plhs[0] = mxCreateNumericArray(numDims, size_img, mxSINGLE_CLASS, mxREAL);
     float *imgout =(float*) mxGetPr(plhs[0]);
     // call C function with the CUDA denoising
   
-    const long imageSize[3]={size_img[0] ,size_img[1],size_img[2] };
+    const long imageSize[3]={size_img[0], size_img[1], third_dim };
+    
     aw_pocs_tv(img,imgout, alpha, imageSize, maxIter,delta); 
     
     //prepareotputs

--- a/MATLAB/Source/minTV.cpp
+++ b/MATLAB/Source/minTV.cpp
@@ -90,25 +90,24 @@ void mexFunction(int  nlhs , mxArray *plhs[],
     // First input should be x from (Ax=b), or the image.
     mxArray const * const image = prhs[0];
     mwSize const numDims = mxGetNumberOfDimensions(image);
+    mwSize third_dim = 1;
     
-    // Image should be dim 3
-    if (numDims!=3){
-      //  mexErrMsgIdAndTxt("minTV:mex", "Image is not 3D");
-    }
+    
     // Now that input is ok, parse it to C data types.
     float  *  img = static_cast<float  *>(mxGetData(image));
-    const mwSize *size_img= mxGetDimensions(image); //get size of image
-    
+    const mwSize *size_img = mxGetDimensions(image); //get size of image    
 
+    // Image should be dim 3
+    if (numDims==3){
+        third_dim = size_img[2];
+    }
     
     // Allocte output image  
-    const long imageSize[3]={size_img[0] ,size_img[1],size_img[2] };
-    plhs[0] = mxCreateNumericArray(3,size_img, mxSINGLE_CLASS, mxREAL);
+    const long imageSize[3]={size_img[0] ,size_img[1], third_dim };
+    plhs[0] = mxCreateNumericArray(numDims, size_img, mxSINGLE_CLASS, mxREAL);
     float *imgout =(float*) mxGetPr(plhs[0]);
-    
     
     pocs_tv(img,imgout, alpha, imageSize, maxIter); 
     
-
     
 }

--- a/MATLAB/Utilities/minimizeAwTV.m
+++ b/MATLAB/Utilities/minimizeAwTV.m
@@ -31,9 +31,7 @@ else
         error('Wrong amount of inputs');
     end
 end
-if ndims(img)==3
-    img=AwminTV(img,dtvg,ng,delta);
-else
-    img=AwminTV(cat(3,img,img),dtvg,ng,delta);
-    img=img(:,:,1);
+
+img=AwminTV(img,dtvg,ng,delta);
+
 end

--- a/MATLAB/Utilities/minimizeTV.m
+++ b/MATLAB/Utilities/minimizeTV.m
@@ -30,10 +30,7 @@ else
         error('Wrong amount of inputs, 1 or 3 expected');
     end
 end
-if ndims(img)==3
-    img=minTV(img,dtvg,ng);
-else
-    img=minTV(cat(3,img,img),dtvg,ng);
-    img=img(:,:,1);
-end
+
+img=minTV(img,dtvg,ng);
+
 end

--- a/Python/tigre/Source/_AwminTV.pyx
+++ b/Python/tigre/Source/_AwminTV.pyx
@@ -31,7 +31,7 @@ def cuda_raise_errors(error_code):
         raise ValueError('TIGRE:Call to aw_pocs_tv failed')
 
 def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 100, float delta=-0.005):
-    src=np.transpose(src,(1,2,0)).copy()  # shift 1st dim to last, match MATLAB order
+#    src=np.transpose(src,(1,2,0)).copy()  # shift 1st dim to last, match MATLAB order
     cdef np.npy_intp size_img[3]
     size_img[0]= <np.npy_intp> src.shape[0]
     size_img[1]= <np.npy_intp> src.shape[1]
@@ -39,10 +39,10 @@ def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter 
 
     cdef float* c_imgout = <float*> malloc(size_img[0] *size_img[1] *size_img[2]* sizeof(float))
 
-    cdef long imgsize[3]
-    imgsize[0] = <long> size_img[0]
+    cdef long imgsize[3] # shift 1st dim to last, match MATLAB order
+    imgsize[0] = <long> size_img[2]
     imgsize[1] = <long> size_img[1]
-    imgsize[2] = <long> size_img[2]
+    imgsize[2] = <long> size_img[0]
 
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
@@ -50,4 +50,5 @@ def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter 
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
     PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
 
-    return np.transpose(imgout,(2,0,1)).copy()
+    return imgout
+#    return np.transpose(imgout,(2,0,1)).copy()

--- a/Python/tigre/Source/_AwminTV.pyx
+++ b/Python/tigre/Source/_AwminTV.pyx
@@ -31,6 +31,7 @@ def cuda_raise_errors(error_code):
         raise ValueError('TIGRE:Call to aw_pocs_tv failed')
 
 def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 100, float delta=-0.005):
+    src=np.transpose(src,(1,2,0)).copy()  # shift 1st dim to last, match MATLAB order
     cdef np.npy_intp size_img[3]
     size_img[0]= <np.npy_intp> src.shape[0]
     size_img[1]= <np.npy_intp> src.shape[1]
@@ -49,4 +50,4 @@ def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter 
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
     PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
 
-    return imgout
+    return np.transpose(imgout,(2,0,1)).copy()

--- a/Python/tigre/Source/_minTV.pyx
+++ b/Python/tigre/Source/_minTV.pyx
@@ -35,7 +35,7 @@ def cuda_raise_errors(error_code):
 
 
 def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 100):
-
+    src=np.transpose(src,(1,2,0)).copy() # shift 1st dim to last, match MATLAB order
     
     cdef np.npy_intp size_img[3]
     size_img[0]= <np.npy_intp> src.shape[0]
@@ -55,4 +55,4 @@ def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
     PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
 
-    return imgout
+    return np.transpose(imgout,(2,0,1)).copy()

--- a/Python/tigre/Source/_minTV.pyx
+++ b/Python/tigre/Source/_minTV.pyx
@@ -35,7 +35,7 @@ def cuda_raise_errors(error_code):
 
 
 def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 100):
-    src=np.transpose(src,(1,2,0)).copy() # shift 1st dim to last, match MATLAB order
+#    src=np.transpose(src,(1,2,0)).copy() # shift 1st dim to last, match MATLAB order
     
     cdef np.npy_intp size_img[3]
     size_img[0]= <np.npy_intp> src.shape[0]
@@ -44,15 +44,16 @@ def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 
 
     cdef float* c_imgout = <float*> malloc(size_img[0] *size_img[1] *size_img[2]* sizeof(float))
 
-    cdef long imgsize[3]
-    imgsize[0] = <long> size_img[0]
+    cdef long imgsize[3] # shift 1st dim to last, match MATLAB order
+    imgsize[0] = <long> size_img[2]
     imgsize[1] = <long> size_img[1]
-    imgsize[2] = <long> size_img[2]
+    imgsize[2] = <long> size_img[0]
 
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
     pocs_tv(c_src, c_imgout, alpha, imgsize, c_maxiter)
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
     PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
-
-    return np.transpose(imgout,(2,0,1)).copy()
+    
+    return imgout
+#    return np.transpose(imgout,(2,0,1)).copy()

--- a/Python/tigre/Source/_tvdenoising.pyx
+++ b/Python/tigre/Source/_tvdenoising.pyx
@@ -50,9 +50,9 @@ def tvdenoise(np.ndarray[np.float32_t, ndim=3] src, int maxiter = 100, float lam
     spacing[2]=<float> 1
 
     cdef long imgsize[3]
-    imgsize[0] = <long> size_img[0]
+    imgsize[0] = <long> size_img[2]
     imgsize[1] = <long> size_img[1]
-    imgsize[2] = <long> size_img[2]
+    imgsize[2] = <long> size_img[0]
 
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter


### PR DESCRIPTION
Two type of changes: 
(1) Python passes the same matrix to GPU for POCS minimization as in MATLAB, makes the results closer to that of MATLAB version; 
(2) Changes to MATLAB version of POCS minimization for 2D cases, no need to duplicate before passing to GPU for processing.