### PR TITLE
Fix typo in python ISTA class initializer

### DIFF
--- a/Python/tigre/algorithms/ista_algorithms.py
+++ b/Python/tigre/algorithms/ista_algorithms.py
@@ -184,7 +184,7 @@ fista = decorator(FISTA, name='FISTA')
 class ISTA(FISTA):
     __doc__ = FISTA.__doc__
 
-    def __int__(self, proj, geo, angles, niter, **kwargs):
+    def __init__(self, proj, geo, angles, niter, **kwargs):
         FISTA.__init__(self, proj, geo, angles, niter, **kwargs)
 
     def run_main_iter(self):


### PR DESCRIPTION
- ```ISTA.__int__``` => ```ISTA.__init__```
- I don't think this change changes its behavior.