### PR TITLE
Fix argument validation of Ax of MATLAB

### DIFF
--- a/MATLAB/Utilities/Ax.m
+++ b/MATLAB/Utilities/Ax.m
@@ -21,7 +21,7 @@ function [ projections ] = Ax(img, geo, angles, varargin )
 
 ptype='Siddon';
 if nargin > 3
-   assert(any(strcmpi(varargin{1},{'Siddon','ray-voxel','interpolated'})),'TIGRE:Ax:InvalidInput','Projection type not understood (4th input).');
+   assert(any(strcmp(varargin{1},{'Siddon','ray-voxel','interpolated'})),'TIGRE:Ax:InvalidInput','Projection type not understood (4th input).');
    ptype=varargin{1};
 end
 


### PR DESCRIPTION
Just a tidying up.

## Expected
Calling 
```
Ax(head, geo, angles, 'Interpolated');   % The first letter of 'Inter...' is upper, which should be lower.
```
to stop in Ax.m at
https://github.com/CERN/TIGRE/blob/165651ceb783438c5d499cfd0ef609639d033f5d/MATLAB/Utilities/Ax.m#L24


## Actual
Passes the line above and stops in Ax_mex.cpp at 
https://github.com/CERN/TIGRE/blob/165651ceb783438c5d499cfd0ef609639d033f5d/MATLAB/Source/Ax_mex.cpp#L84-L85

