### PR TITLE
Fixed compilation error

### DIFF
--- a/Common/CUDA/Siddon_projection_parallel.cu
+++ b/Common/CUDA/Siddon_projection_parallel.cu
@@ -188,27 +188,27 @@ __global__ void kernelPixelDetector_parallel( Geometry geo,
     float imin,imax,jmin,jmax;
     // for X
     if( source.x<pixel1D.x){
-        imin=(am==axm)? 1.0f             : ceil (source.x+am*ray.x);
-        imax=(aM==axM)? geo.nVoxelX      : floor(source.x+aM*ray.x);
+        imin=(am==axm)? 1.0f             : ceilf (source.x+am*ray.x);
+        imax=(aM==axM)? geo.nVoxelX      : floorf(source.x+aM*ray.x);
     }else{
-        imax=(am==axm)? geo.nVoxelX-1.0f : floor(source.x+am*ray.x);
-        imin=(aM==axM)? 0.0f             : ceil (source.x+aM*ray.x);
+        imax=(am==axm)? geo.nVoxelX-1.0f : floorf(source.x+am*ray.x);
+        imin=(aM==axM)? 0.0f             : ceilf (source.x+aM*ray.x);
     }
     // for Y
     if( source.y<pixel1D.y){
-        jmin=(am==aym)? 1.0f             : ceil (source.y+am*ray.y);
-        jmax=(aM==ayM)? geo.nVoxelY      : floor(source.y+aM*ray.y);
+        jmin=(am==aym)? 1.0f             : ceilf (source.y+am*ray.y);
+        jmax=(aM==ayM)? geo.nVoxelY      : floorf(source.y+aM*ray.y);
     }else{
-        jmax=(am==aym)? geo.nVoxelY-1.0f : floor(source.y+am*ray.y);
-        jmin=(aM==ayM)? 0.0f             : ceil (source.y+aM*ray.y);
+        jmax=(am==aym)? geo.nVoxelY-1.0f : floorf(source.y+am*ray.y);
+        jmin=(aM==ayM)? 0.0f             : ceilf (source.y+aM*ray.y);
     }
 //     // for Z
 //     if( source.z<pixel1D.z){
-//         kmin=(am==azm)? 1             : ceil (source.z+am*ray.z);
-//         kmax=(aM==azM)? geo.nVoxelZ : floor(source.z+aM*ray.z);
+//         kmin=(am==azm)? 1             : ceilf (source.z+am*ray.z);
+//         kmax=(aM==azM)? geo.nVoxelZ : floorf(source.z+aM*ray.z);
 //     }else{
-//         kmax=(am==azm)? geo.nVoxelZ-1 : floor(source.z+am*ray.z);
-//         kmin=(aM==azM)? 0             : ceil (source.z+aM*ray.z);
+//         kmax=(am==azm)? geo.nVoxelZ-1 : floorf(source.z+am*ray.z);
+//         kmin=(aM==azM)? 0             : ceilf (source.z+aM*ray.z);
 //     }
     
     // get intersection point N1. eq(20-21) [(also eq 9-10)]


### PR DESCRIPTION
## Background

I compiled TIGRE for the first time in the several weeks and it failed.
It also failed in the past revisions that were successful at the time.
Updating Visual Studio 2019 and VS code are the only thing that I did recently.
Error occured in `Siddon_projection_parallel.cu` but not in `Siddon_projection.cu` which uses `ceilf` and `floorf` instead of `ceil` and `floor`.

## Expected

`setup.py` finishes successfully.

## Actual
`setup.py` terminates with error.

```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin\nvcc.exe -c ../Common/CUDA/Siddon_projection_parallel.cu -o build\temp.win-amd64-3.8\Release\../Common/CUDA/Siddon_projection_parallel.obj -IC:\opt\anaconda3\envs\dev\lib\site-packages\numpy\core\include "-IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\include" -I../Common/CUDA/ -IC:\opt\anaconda3\envs\dev\include -IC:\opt\anaconda3\envs\dev\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.28.29910\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.28.29910\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" "-IC:\Program Files (x86)\Intel\IPP\6.1.6.056\em64t\include" "-IC:\Program Files (x86)\Intel\IPP\6.1.6.056\ia32\include" -Xcompiler /EHsc -Xcompiler /wd4819 -Xcompiler /MD -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_86,code=sm_86 --ptxas-options=-v -c --default-stream=per-thread --define-macro IS_FOR_PYTIGRE
../Common/CUDA/Siddon_projection_parallel.cu(159): warning: variable "azm" was declared but never referenced

../Common/CUDA/Siddon_projection_parallel.cu(160): warning: variable "azM" was declared but never referenced

../Common/CUDA/Siddon_projection_parallel.cu(313): warning: variable "divangle" was declared but never referenced

../Common/CUDA/Siddon_projection_parallel.cu(191): error: calling a __host__ function("__ceilf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(191): error: identifier "__ceilf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(192): error: calling a __host__ function("__floorf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(192): error: identifier "__floorf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(194): error: calling a __host__ function("__floorf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(194): error: identifier "__floorf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(195): error: calling a __host__ function("__ceilf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(195): error: identifier "__ceilf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(199): error: calling a __host__ function("__ceilf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(199): error: identifier "__ceilf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(200): error: calling a __host__ function("__floorf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(200): error: identifier "__floorf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(202): error: calling a __host__ function("__floorf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(202): error: identifier "__floorf" is undefined in device code

../Common/CUDA/Siddon_projection_parallel.cu(203): error: calling a __host__ function("__ceilf") from a __global__ function("kernelPixelDetector_parallel") is not allowed

../Common/CUDA/Siddon_projection_parallel.cu(203): error: identifier "__ceilf" is undefined in device code

16 errors detected in the compilation of "../Common/CUDA/Siddon_projection_parallel.cu".
```

## Environment

| Software        | Version           | 
| ------------- |:-------------:|
|**Windows**| 10  64bit |
|**Python(anaconda)**|  3.8.5 |
|**CUDA**| 11.1|
|**Visual Studio**| 2019 (16.9.1) |
|**GPU**| GTX1060 |
