### PR TITLE
Add show_plot option to plot-functions in Python

### DIFF
--- a/Python/tigre/utilities/plotimg.py
+++ b/Python/tigre/utilities/plotimg.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import matplotlib
 import matplotlib.animation as animation
 import numpy as np
 from matplotlib import pyplot as plt
@@ -15,7 +16,8 @@ class plotImg:  # noqa: N801
     """
 
     def __init__(
-        self, cube, dim=None, slice=None, step=1, savegif=None, colormap="gray", clims=None
+        self, cube, dim=None, slice=None, step=1, savegif=None, colormap="gray", clims=None,
+        show_plot = None
     ):
         self.cube = cube
         self.dim = dim
@@ -31,6 +33,22 @@ class plotImg:  # noqa: N801
         else:
             self.min_val = clims[0]
             self.max_val = clims[1]
+        if show_plot is None:
+            # https://matplotlib.org/stable/tutorials/introductory/usage.html#backends
+            backend = matplotlib.get_backend()
+            if backend in ["GTK3Agg", "GTK3Cairo", "MacOSX", "nbAgg",
+                           "Qt4Agg", "Qt4Cairo", "Qt5Agg", "Qt5Cairo",
+                           "TkAgg", "TkCairo", "WebAgg", "WX",
+                           "WXAgg", "WXCairo",
+                           "module://ipykernel.pylab.backend_inline"]:
+                self.show_plot = True
+            elif backend in ["agg", "cairo", "pdf", "pgf", "ps",
+                             "svg", "template"]:
+                self.show_plot = False
+            else:
+                self.show_plot = True
+        else:
+            self.show_plot = show_plot
         if self.step is None or self.step == 0:
             self.step = 1
         if self.savegif == "":
@@ -110,9 +128,9 @@ class plotImg:  # noqa: N801
         )
         if self.savegif is not None:
             ani.save(self.savegif, writer="pillow")
-            plt.show()
+            self._show()
         else:
-            plt.show()
+            self._show()
 
     def slicer(self):
 
@@ -146,7 +164,10 @@ class plotImg:  # noqa: N801
                 vmin=self.min_val,
                 vmax=self.max_val,
             )
-        plt.show()
+        self._show()
 
+    def _show(self):
+        if self.show_plot:
+            plt.show()
 
 plotimg = plotImg

--- a/Python/tigre/utilities/plotproj.py
+++ b/Python/tigre/utilities/plotproj.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import matplotlib
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,6 +33,10 @@ class plotProj:
         "      Step is 1 by default.\n"
         "savegif: string, optional\n"
         "         Saves the image as .gif with the file name\n"
+        "show_plot: bool, optional\n"
+        "           Sets whether to show the plot.\n"
+        "           Default is None, automatically detects matplotlib backend\n"
+        "           and decides whether to call plt.show.\n"
         "Examples:\n"
         "---------\n"
         "a=np.ones([3,3,3])\n"
@@ -51,6 +56,7 @@ class plotProj:
         savegif=None,
         colormap="gray",
         clims=None,
+        show_plot = None,
     ):
         self.proj = proj
         self.dim = dim
@@ -67,6 +73,20 @@ class plotProj:
         else:
             self.min_val = clims[0]
             self.max_val = clims[1]
+        if show_plot is None:
+            # https://matplotlib.org/stable/tutorials/introductory/usage.html#backends
+            backend = matplotlib.get_backend()
+            if backend in ["GTK3Agg", "GTK3Cairo", "MacOSX", "nbAgg",
+                           "Qt4Agg", "Qt4Cairo", "Qt5Agg", "Qt5Cairo",
+                           "TkAgg", "TkCairo", "WebAgg", "WX",
+                           "WXAgg", "WXCairo",
+                           "module://ipykernel.pylab.backend_inline"]:
+                self.show_plot = True
+            elif backend in ["agg", "cairo", "pdf", "pgf", "ps",
+                             "svg", "template"]:
+                self.show_plot = False
+            else:
+                self.show_plot = True
         if self.step is None or self.step == 0:
             self.step = 1
         if self.savegif == "":
@@ -153,9 +173,9 @@ class plotProj:
         )
         if self.savegif is not None:
             ani.save(self.savegif, writer="pillow")
-            plt.show()
+            self._show()
         else:
-            plt.show()
+            self._show()
 
     def slicer(self):
 
@@ -191,10 +211,14 @@ class plotProj:
                 vmin=self.min_val,
                 vmax=self.max_val,
             )
-        plt.show()
+        self._show()
+
+    def _show(self):
+        if self.show_plot:
+            plt.show()
 
 
-def plotSinogram(proj, posV):  # noqa: N803
+def plotSinogram(proj, posV, show_plot = None):  # noqa: N803
     """
     plotSinogram(proj, posV)
         plots sinogram at V=posV
@@ -204,7 +228,7 @@ def plotSinogram(proj, posV):  # noqa: N803
     proj : Any 3D numpy array
     posV : integer. in range of 0:proj.shape[1].
     """
-    plotProj(proj, dim="V", slice=posV)
+    plotProj(proj, dim="V", slice=posV, show_plot=show_plot)
 
 
 plotproj = plotProj


### PR DESCRIPTION
# Summary

A solution for #285

Add show_plot option to plot-functions in Python.

# Modified

 * if not set, `plotImg`, `plotProj` detects the matplotlib backend end and if it is a non-GUI backend, they don't call plt.show().
    * the values of backend are taken from https://matplotlib.org/stable/tutorials/introductory/usage.html#backends
    * The backend of jupyter and VSCode was "module://ipykernel.pylab.backend_inline"
         * In my environment, single page plot can be shown on VSCode and jupyter, but animations are not.
 * User can force the functions not to call plt.show() by settting show_plot=False.


#  Test
## Code
```
import tigre
import numpy as np
import matplotlib
import matplotlib.pyplot as plt
from tigre.utilities import sl3d

geo = tigre.geometry_default(high_resolution=False)
angles = np.linspace(0, 2 * np.pi, 30)
head = sl3d.shepp_logan_3d(list(geo.nVoxel))
projections = tigre.Ax(head, geo, angles)

print(f"matplotlib.get_backend()= {matplotlib.get_backend()}")
backend_orig = matplotlib.get_backend() # "Qt5Agg" 

# Test plotImg
## Show
matplotlib.use(backend_orig)   # "Qt5Agg" is set.
tigre.plotImg(head, dim="Z", slice=head.shape[0]//4) # shown
## Set non-GUI matplotlib backend
matplotlib.use("agg")   #
tigre.plotImg(head, dim="Z", slice=head.shape[0]//2) # not shown 
tigre.plotImg(head, dim="Y", savegif="Yslice.gif")  # plot not shown on screen, but file is saved, 

# Test plotProj
## Show.
matplotlib.use(backend_orig)   # "Qt5Agg" is set.
tigre.plotProj(projections, angles)  # shown
## Set non-GUI matplotlib backend
matplotlib.use("agg")
tigre.plotSinogram(projections, projections.shape[1]//2)  # not shown
```

## Environment

* Windows 10
*  Python 3.8.5 (anaconda)
*  matplotlib 3.3.1
*  Visual studio 2019 (16.9.4)
