### PR TITLE
Fix and refactor checkDevices

### DIFF
--- a/Common/CUDA/GpuIds.cpp
+++ b/Common/CUDA/GpuIds.cpp
@@ -1,5 +1,7 @@
 #include "GpuIds.hpp"
 #include <stdlib.h>
+#include <string.h>
+#include <cuda_runtime_api.h>
 
 GpuIds::~GpuIds() {
     free(m_piDeviceIds); m_piDeviceIds = nullptr;
@@ -46,4 +48,23 @@ void GpuIds::SetAllGpus(int iTotalDeviceCount) {
     }
     SetIds(iTotalDeviceCount, aiIds);
     free(aiIds); aiIds = 0;    
+}
+
+bool GpuIds::AreEqualDevices() const {
+    int deviceCount = this->GetLength();
+    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
+    char devicename[devicenamelength];
+    cudaDeviceProp deviceProp;
+    for (int dev = 0; dev < deviceCount; dev++) {
+        // cudaSetDevice(m_piDeviceIds[dev]);
+        cudaGetDeviceProperties(&deviceProp, m_piDeviceIds[dev]);
+        if (dev>0) {
+            if (strcmp(devicename, deviceProp.name) != 0) {
+                return false;
+            }
+        }
+        memset(devicename, 0, devicenamelength);
+        strcpy(devicename, deviceProp.name);
+    }
+    return true;
 }

--- a/Common/CUDA/GpuIds.hpp
+++ b/Common/CUDA/GpuIds.hpp
@@ -11,6 +11,7 @@ struct GpuIds {
     void SetAllGpus(int iTotalDeviceCount);
     int& operator[](int iIndex);
     int operator[](int iIndex) const;
+    bool AreEqualDevices() const;
 };
 #endif
 

--- a/Common/CUDA/POCS_TV.cu
+++ b/Common/CUDA/POCS_TV.cu
@@ -269,7 +269,7 @@ do { \
         // 2.-All available devices are equal, they are the same machine (warning thrown)
         // Check the available devices, and if they are the same
         if (!gpuids.AreEqualDevices()) {
-            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
         }
         
         int dev;

--- a/Common/CUDA/POCS_TV.cu
+++ b/Common/CUDA/POCS_TV.cu
@@ -266,25 +266,13 @@ do { \
         //
         // CODE assumes
         // 1.-All available devices are usable by this code
-        // 2.-All available devices are equal, they are the same machine (warning trhown)
-        int dev;
-        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-        char devicename[devicenamelength];
-        cudaDeviceProp deviceProp;
-        
-        for (dev = 0; dev < deviceCount; dev++) {
-            cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-            if (dev>0){
-                if (strcmp(devicename,deviceProp.name)!=0){
-                    mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
-                    break;
-                }
-            }
-            memset(devicename, 0, devicenamelength);
-            strcpy(devicename, deviceProp.name);
+        // 2.-All available devices are equal, they are the same machine (warning thrown)
+        // Check the available devices, and if they are the same
+        if (!gpuids.AreEqualDevices()) {
+            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
         }
         
+        int dev;
         
         // We don't know if the devices are being used. lets check that. and only use the amount of memory we need.
 

--- a/Common/CUDA/POCS_TV.cu
+++ b/Common/CUDA/POCS_TV.cu
@@ -274,7 +274,7 @@ do { \
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, dev);
+            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
             if (dev>0){
                 if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");

--- a/Common/CUDA/POCS_TV2.cu
+++ b/Common/CUDA/POCS_TV2.cu
@@ -291,7 +291,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, dev);
+            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
             if (dev>0){
                 if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");

--- a/Common/CUDA/POCS_TV2.cu
+++ b/Common/CUDA/POCS_TV2.cu
@@ -278,7 +278,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
         int deviceCount = gpuids.GetLength();
         cudaCheckErrors("Device query fail");
         if (deviceCount == 0) {
-            mexErrMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","There are no available device(s) that support CUDA\n");
+            mexErrMsgIdAndTxt("minimizeAwTV:POCS_TV2:GPUselect","There are no available device(s) that support CUDA\n");
         }
         //
         // CODE assumes
@@ -286,7 +286,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
         // 2.-All available devices are equal, they are the same machine (warning thrown)
         // Check the available devices, and if they are the same
         if (!gpuids.AreEqualDevices()) {
-            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+            mexWarnMsgIdAndTxt("minimizeAwTV:POCS_TV2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
         }
         int dev;
         
@@ -355,7 +355,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
 
             // Assert
             if (mem_GPU_global< 3*mem_img_each_GPU+mem_auxiliary){
-                mexErrMsgIdAndTxt("minimizeTV:POCS_TV:GPU","Assertion Failed. Logic behind spliting flawed! Please tell: ander.biguri@gmail.com\n");
+                mexErrMsgIdAndTxt("minimizeAwTV:POCS_TV2:GPU","Assertion Failed. Logic behind spliting flawed! Please tell: ander.biguri@gmail.com\n");
             }
         }
         
@@ -363,7 +363,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
          // Assert
        
         if ((slices_per_split+buffer_length*2)*image_size[0]*image_size[1]* sizeof(float)!= mem_img_each_GPU){
-            mexErrMsgIdAndTxt("minimizeTV:POCS_TV:GPU","Assertion Failed. Memory needed calculation broken! Please tell: ander.biguri@gmail.com\n");
+            mexErrMsgIdAndTxt("minimizeAwTV:POCS_TV2:GPU","Assertion Failed. Memory needed calculation broken! Please tell: ander.biguri@gmail.com\n");
         }
         
         
@@ -392,7 +392,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
        unsigned long long buffer_pixels=buffer_length*image_size[0]*image_size[1];
         float* buffer;
         if(splits>1){
-            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:Image_split","Your image can not be fully split between the available GPUs. The computation of minTV will be significantly slowed due to the image size.\nApproximated mathematics turned on for computational speed.");
+            mexWarnMsgIdAndTxt("minimizeAwTV:POCS_TV2:Image_split","Your image can not be fully split between the available GPUs. The computation of minTV will be significantly slowed due to the image size.\nApproximated mathematics turned on for computational speed.");
         }else{
             cudaMallocHost((void**)&buffer,buffer_length*image_size[0]*image_size[1]*sizeof(float));
         }

--- a/Common/CUDA/POCS_TV2.cu
+++ b/Common/CUDA/POCS_TV2.cu
@@ -284,24 +284,11 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
         // CODE assumes
         // 1.-All available devices are usable by this code
         // 2.-All available devices are equal, they are the same machine (warning thrown)
-        int dev;
-        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-        char devicename[devicenamelength];
-        cudaDeviceProp deviceProp;
-        
-        for (dev = 0; dev < deviceCount; dev++) {
-            cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-            if (dev>0){
-                if (strcmp(devicename,deviceProp.name)!=0){
-                    mexWarnMsgIdAndTxt("minimizeTV:POCS_TV:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
-                    break;
-                }
-            }
-            memset(devicename, 0, devicenamelength);
-            strcpy(devicename, deviceProp.name);
+        // Check the available devices, and if they are the same
+        if (!gpuids.AreEqualDevices()) {
+            mexWarnMsgIdAndTxt("minimizeTV:POCS_TV2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
         }
-        
+        int dev;
         
         // We don't know if the devices are being used. lets check that. and only use the amount of memory we need.
         // check free memory

--- a/Common/CUDA/Siddon_projection.cu
+++ b/Common/CUDA/Siddon_projection.cu
@@ -281,7 +281,7 @@ int siddon_ray_projection(float* img, Geometry geo, float** result,float const *
     // 2.-All available devices are equal, they are the same machine (warning thrown)
     // Check the available devices, and if they are the same
     if (!gpuids.AreEqualDevices()) {
-        mexWarnMsgIdAndTxt("Ax:Siddon_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+        mexWarnMsgIdAndTxt("Ax:Siddon_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
     }
     int dev;
     

--- a/Common/CUDA/Siddon_projection.cu
+++ b/Common/CUDA/Siddon_projection.cu
@@ -279,26 +279,11 @@ int siddon_ray_projection(float* img, Geometry geo, float** result,float const *
     // CODE assumes
     // 1.-All available devices are usable by this code
     // 2.-All available devices are equal, they are the same machine (warning thrown)
-    int dev;
-    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-    char devicename[devicenamelength];
-    cudaDeviceProp deviceProp;
-    
-    for (dev = 0; dev < deviceCount; dev++) {
-        cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-        if (dev>0){
-            if (strcmp(devicename,deviceProp.name)!=0){
-                mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
-                break;
-            }
-        }
-        memset(devicename, 0, devicenamelength);
-        strcpy(devicename, deviceProp.name);
+    // Check the available devices, and if they are the same
+    if (!gpuids.AreEqualDevices()) {
+        mexWarnMsgIdAndTxt("Ax:Siddon_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
     }
-    
-    
-    
+    int dev;
     
     // Check free memory
     size_t mem_GPU_global;

--- a/Common/CUDA/Siddon_projection.cu
+++ b/Common/CUDA/Siddon_projection.cu
@@ -286,7 +286,7 @@ int siddon_ray_projection(float* img, Geometry geo, float** result,float const *
     
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, dev);
+        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
         if (dev>0){
             if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");

--- a/Common/CUDA/ray_interpolated_projection.cu
+++ b/Common/CUDA/ray_interpolated_projection.cu
@@ -229,7 +229,7 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, dev);
+        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
         if (dev>0){
             if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");

--- a/Common/CUDA/ray_interpolated_projection.cu
+++ b/Common/CUDA/ray_interpolated_projection.cu
@@ -224,7 +224,7 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     // 2.-All available devices are equal, they are the same machine (warning thrown)
     // Check the available devices, and if they are the same
     if (!gpuids.AreEqualDevices()) {
-        mexWarnMsgIdAndTxt("Ax:Interpolated_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+        mexWarnMsgIdAndTxt("Ax:Interpolated_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
     }
     int dev;
     

--- a/Common/CUDA/ray_interpolated_projection.cu
+++ b/Common/CUDA/ray_interpolated_projection.cu
@@ -221,24 +221,12 @@ int interpolation_projection(float  *  img, Geometry geo, float** result,float c
     //
     // CODE assumes
     // 1.-All available devices are usable by this code
-    // 2.-All available devices are equal, they are the same machine (warning trhown)
-    int dev;
-    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-    char devicename[devicenamelength];
-    cudaDeviceProp deviceProp;
-    
-    for (dev = 0; dev < deviceCount; dev++) {
-        cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-        if (dev>0){
-            if (strcmp(devicename,deviceProp.name)!=0){
-                mexWarnMsgIdAndTxt("Ax:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
-                break;
-            }
-        }
-        memset(devicename, 0, devicenamelength);
-        strcpy(devicename, deviceProp.name);
+    // 2.-All available devices are equal, they are the same machine (warning thrown)
+    // Check the available devices, and if they are the same
+    if (!gpuids.AreEqualDevices()) {
+        mexWarnMsgIdAndTxt("Ax:Interpolated_projection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
     }
+    int dev;
     
     // Check free memory
     size_t mem_GPU_global;

--- a/Common/CUDA/tvdenoising.cu
+++ b/Common/CUDA/tvdenoising.cu
@@ -186,7 +186,7 @@ do { \
         // 2.-All available devices are equal, they are the same machine (warning thrown)
         // Check the available devices, and if they are the same
         if (!gpuids.AreEqualDevices()) {
-            mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+            mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
         }
         int dev;
 

--- a/Common/CUDA/tvdenoising.cu
+++ b/Common/CUDA/tvdenoising.cu
@@ -183,25 +183,13 @@ do { \
         //
         // CODE assumes
         // 1.-All available devices are usable by this code
-        // 2.-All available devices are equal, they are the same machine (warning trhown)
-        int dev;
-        const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-        char devicename[devicenamelength];
-        cudaDeviceProp deviceProp;
-        
-        for (dev = 0; dev < deviceCount; dev++) {
-            cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-            if (dev>0){
-                if (strcmp(devicename,deviceProp.name)!=0){
-                    mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");
-                    break;
-                }
-            }
-            memset(devicename, 0, devicenamelength);
-            strcpy(devicename, deviceProp.name);
+        // 2.-All available devices are equal, they are the same machine (warning thrown)
+        // Check the available devices, and if they are the same
+        if (!gpuids.AreEqualDevices()) {
+            mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
         }
-        
+        int dev;
+
         // We don't know if the devices are being used. lets check that. and only use the amount of memory we need.
         
         size_t mem_GPU_global;

--- a/Common/CUDA/tvdenoising.cu
+++ b/Common/CUDA/tvdenoising.cu
@@ -191,7 +191,7 @@ do { \
         
         for (dev = 0; dev < deviceCount; dev++) {
             cudaSetDevice(gpuids[dev]);
-            cudaGetDeviceProperties(&deviceProp, dev);
+            cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
             if (dev>0){
                 if (strcmp(devicename,deviceProp.name)!=0){
                     mexWarnMsgIdAndTxt("tvDenoise:tvdenoising:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n POCS_TV.cu line 277.");

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -307,7 +307,7 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
     // 2.-All available devices are equal, they are the same machine (warning thrown)
     // Check the available devices, and if they are the same
     if (!gpuids.AreEqualDevices()) {
-        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
     }
 
     int dev;

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -624,7 +624,7 @@ void checkDevices(const GpuIds& gpuids){
     cudaDeviceProp deviceProp;
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, dev);
+        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
         if (dev>0){
             if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Atb:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");

--- a/Common/CUDA/voxel_backprojection.hpp
+++ b/Common/CUDA/voxel_backprojection.hpp
@@ -55,6 +55,5 @@ void eulerZYZT(Geometry geo, Point3D* point);
 void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S);
 void createGeoArray(unsigned int image_splits, Geometry geo,Geometry* geoArray, unsigned int nangles);
 void freeGeoArray(unsigned int splits,Geometry* geoArray);
-void checkDevices(const GpuIds& gpuids);
 void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global);
 #endif

--- a/Common/CUDA/voxel_backprojection2.cu
+++ b/Common/CUDA/voxel_backprojection2.cu
@@ -328,9 +328,16 @@ int voxel_backprojection2(float * projections, Geometry geo, float* result,float
     }
     
     
+    // CODE assumes
+    // 1.-All available devices are usable by this code
+    // 2.-All available devices are equal, they are the same machine (warning thrown)
     // Check the available devices, and if they are the same
+    if (!gpuids.AreEqualDevices()) {
+        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+    }
+
     int dev;
-    checkDevices(gpuids);
+
     
     // Split the CT problem
     unsigned int split_image;
@@ -690,28 +697,6 @@ void CreateTexture2(const GpuIds& gpuids, float* projectiondata,Geometry geo,cud
     }
 }
 #ifndef BACKPROJECTION_HPP
-void checkDevices(const GpuIds& gpuids){
-    // CODE assumes
-    // 1.-All available devices are usable by this code
-    // 2.-All available devices are equal, they are the same machine (warning thrown)
-    int dev;
-    int deviceCount = gpuids.GetLength();
-    const int devicenamelength = 256;  // The length 256 is fixed by spec of cudaDeviceProp::name
-    char devicename[devicenamelength];
-    cudaDeviceProp deviceProp;
-    for (dev = 0; dev < deviceCount; dev++) {
-        cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
-        if (dev>0){
-            if (strcmp(devicename,deviceProp.name)!=0){
-                mexWarnMsgIdAndTxt("Atb:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
-                break;
-            }
-        }
-        memset(devicename, 0, devicenamelength);
-        strcpy(devicename, deviceProp.name);
-    }
-}
 void splitCTbackprojection(const GpuIds& gpuids, Geometry geo,int nalpha, unsigned int* split_image, unsigned int * split_projections){
     
     

--- a/Common/CUDA/voxel_backprojection2.cu
+++ b/Common/CUDA/voxel_backprojection2.cu
@@ -701,7 +701,7 @@ void checkDevices(const GpuIds& gpuids){
     cudaDeviceProp deviceProp;
     for (dev = 0; dev < deviceCount; dev++) {
         cudaSetDevice(gpuids[dev]);
-        cudaGetDeviceProperties(&deviceProp, dev);
+        cudaGetDeviceProperties(&deviceProp, gpuids[dev]);
         if (dev>0){
             if (strcmp(devicename,deviceProp.name)!=0){
                 mexWarnMsgIdAndTxt("Atb:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");

--- a/Common/CUDA/voxel_backprojection2.cu
+++ b/Common/CUDA/voxel_backprojection2.cu
@@ -333,7 +333,7 @@ int voxel_backprojection2(float * projections, Geometry geo, float* result,float
     // 2.-All available devices are equal, they are the same machine (warning thrown)
     // Check the available devices, and if they are the same
     if (!gpuids.AreEqualDevices()) {
-        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed. \n Siddon_projection.cu line 275.");
+        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection2:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
     }
 
     int dev;

--- a/Common/CUDA/voxel_backprojection2.hpp
+++ b/Common/CUDA/voxel_backprojection2.hpp
@@ -60,6 +60,5 @@ void splitCTbackprojection(const GpuIds& gpuids,Geometry geo,int nalpha, unsigne
 void computeDeltasCube(Geometry geo, int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S);
 void createGeoArray(unsigned int image_splits, Geometry geo,Geometry* geoArray, unsigned int nangles);
 void freeGeoArray(unsigned int splits,Geometry* geoArray);
-void checkDevices(const GpuIds& gpuids);
 void checkFreeMemory(const GpuIds& gpuids, size_t *mem_GPU_global);
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -24,3 +24,4 @@ Many contributors have made this possible. Sincere thanks.
 - ComputeV errored for triplet angle inputs, fixed
 - Fixed many python algorithm bugs (lost track of some)
 - Removed many unnecesary files
+- Fix and refactor checkDevices


### PR DESCRIPTION
I think I found a bug at `checkDevices` codes.
For example, 
https://github.com/CERN/TIGRE/blob/3977143a6dd8390366b1f33fa82ae8adc325233b/Common/CUDA/voxel_backprojection.cu#L625-L627

* `dev` is not the ID of GPU but an iterator.
* The device ID of the GPU is `gpuids[dev]`

so this code will behave unexpectedly if the users GPUs are
```
0: Type A, 1: Type B, 2: Type B
```
and `gpuids = [1,2]`.

Unfortunately my GPUs are
```
0: Type A, 1: Type A, 2: Type B
```
I, therefore, cannot test the exact case, but it seems clear. 


Additionally,
https://github.com/CERN/TIGRE/blob/3977143a6dd8390366b1f33fa82ae8adc325233b/Common/CUDA/voxel_backprojection.cu#L626
is not necessary.

I think this check can be done by `GpuIds` class.

The bugfix is done at 9fe4ed7c04e9202d2f79813ff21d7119c46f8973.
Removing redundant line and refactoring are done at 8e03d5e5a44e32a3eae903bf560007df6749f172.

Tests are WIP

- [x] Ax ( [cone, parallel] x [Siddon, interpolated] )    (parallel does not check devices.)
- [x] Atb ([cone, parallel] x [matched, FDK] )
- [x] POCS_TV
- [x] POCS_TV2
- [x] tvdenoising
- [x] voxel_backprojection2





