### PR TITLE
Fix python BP type variable name and default

### DIFF
--- a/MATLAB/Algorithms/MLEM.m
+++ b/MATLAB/Algorithms/MLEM.m
@@ -52,7 +52,7 @@ for ii=1:niter
     den(den<=0.)=inf;
     auxMLEM=proj./den;
     
-    imgupdate = Atb(auxMLEM, geo,angles,'gpuids',gpuids)./W;
+    imgupdate = Atb(auxMLEM, geo,angles,'matched','gpuids',gpuids)./W;
     res = max(res.*imgupdate,0.);
     
     if measurequality

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -45,13 +45,13 @@ class CGLS(IterativeReconAlg):  # noqa: D101
             self.parameter_history = parameter_history
 
         self.__r__ = self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        self.__p__ = Atb(self.__r__, self.geo, self.angles, gpuids=self.gpuids)
+        self.__p__ = Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
         p_norm = np.linalg.norm(self.__p__.ravel(), 2)
         self.__gamma__ = p_norm * p_norm
 
     def reinitialise_cgls(self):
         self.__r__ = self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        self.__p__ = Atb(self.__r__, self.geo, self.angles, gpuids=self.gpuids)
+        self.__p__ = Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
         p_norm = np.linalg.norm(self.__p__.ravel(), 2)
         self.__gamma__ = p_norm * p_norm
 
@@ -101,7 +101,7 @@ class CGLS(IterativeReconAlg):  # noqa: D101
                 self.re_init_at_iteration = i
 
             self.__r__ -= alpha * q
-            s = tigre.Atb(self.__r__, self.geo, self.angles, gpuids=self.gpuids)
+            s = tigre.Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
             s_norm = np.linalg.norm(s)
 
             gamma1 = s_norm * s_norm

--- a/Python/tigre/algorithms/statistical_algorithms.py
+++ b/Python/tigre/algorithms/statistical_algorithms.py
@@ -65,7 +65,7 @@ class MLEM(IterativeReconAlg):  # noqa: D101
 
             # update
             # tic = time.process_time()
-            img = Atb(auxmlem, self.geo, self.angles, gpuids=self.gpuids) / self.W
+            img = Atb(auxmlem, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) / self.W
             # toc = time.process_time()
             # print('Atb time: {}'.format(toc-tic))
             # img[img == np.nan] = 0.

--- a/Python/tigre/utilities/Atb.py
+++ b/Python/tigre/utilities/Atb.py
@@ -6,7 +6,7 @@ from _Atb import _Atb_ext
 from .gpu import GpuIds
 
 
-def Atb(projections, geo, angles, krylov="matched", **kwargs):
+def Atb(projections, geo, angles, backprojection_type="FDK", **kwargs):
     if projections.dtype != np.float32:
         raise TypeError("Input data should be float32, not " + str(projections.dtype))
     if not np.isreal(projections).all():
@@ -33,4 +33,4 @@ def Atb(projections, geo, angles, krylov="matched", **kwargs):
     else:
         gpuids = kwargs["gpuids"]
 
-    return _Atb_ext(projections, geox, geox.angles, krylov, geox.mode, gpuids=gpuids)
+    return _Atb_ext(projections, geox, geox.angles, backprojection_type, geox.mode, gpuids=gpuids)

--- a/Python/tigre/utilities/cuda_interface/_Atb.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Atb.pyx
@@ -28,7 +28,7 @@ def cuda_raise_errors(error_code):
 
 
 
-def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[np.float32_t, ndim=2] angles, krylov="FDK", mode="cone", gpuids=None):
+def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[np.float32_t, ndim=2] angles, backprojection_type="FDK", mode="cone", gpuids=None):
 
     cdef c_GpuIds* c_gpuids = convert_to_c_gpuids(gpuids)
     if not c_gpuids:
@@ -41,10 +41,10 @@ def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[
     cdef float* c_model = <float*> malloc(geometry.nVoxel[0] * geometry.nVoxel[1] * geometry.nVoxel[2] * sizeof(float))
     cdef float* c_angles = <float*> angles.data
 
-    # TODO: Error if krylov isn't FDK or matched
-    if krylov == "matched":
+    # TODO: Error if backprojection_type isn't FDK or matched
+    if backprojection_type == "matched":
         krylov_proj = True
-    elif krylov == "FDK":
+    elif backprojection_type == "FDK":
         krylov_proj = False
     else:
         print("Warning: Unknown backprojector, using default matched")

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ Many contributors have made this possible. Sincere thanks.
 - Add NikonDataLoader() to python. By outside github contrib.
 - Code quality optional code added, to be able to maintain decent python.
 - Demos for python available
-- Add 3D Shepp-Logan head phantom to python.
+- Add 3D Shepp-Logan head phantom to Python.
 
 ## BugFix
 
@@ -25,3 +25,4 @@ Many contributors have made this possible. Sincere thanks.
 - Fixed many python algorithm bugs (lost track of some)
 - Removed many unnecesary files
 - Fix and refactor checkDevices
+- Fix backprojection type variable name and its default value in Python.


### PR DESCRIPTION
# Summary

* Made backprojection type variable name more sensible.
* Made its default value same as Matlab.
     * This makes algorithms use the correct backprojection (matched for FISTA and CGLS, FDK for the rest).
* See #209

# TODO
- [x] Tests
   - [x] FDK
   - [x] matched
- [x] changelog.md

