### PR TITLE
Add OS_AwASD_POCS and fix a bug of not splitting angle blocks in POCs

### DIFF
--- a/Python/tigre/algorithms/__init__.py
+++ b/Python/tigre/algorithms/__init__.py
@@ -13,6 +13,7 @@ from .krylov_subspace_algorithms import cgls
 from .pocs_algorithms import asd_pocs
 from .pocs_algorithms import os_asd_pocs
 from .pocs_algorithms import awasd_pocs
+from .pocs_algorithms import os_awasd_pocs
 from .single_pass_algorithms import fdk
 from .single_pass_algorithms import fbp
 from .statistical_algorithms import mlem

--- a/Python/tigre/algorithms/pocs_algorithms.py
+++ b/Python/tigre/algorithms/pocs_algorithms.py
@@ -196,7 +196,10 @@ class AwASD_POCS(ASD_POCS):  # noqa: D101, N801
     def __init__(self, proj, geo, angles, niter, **kwargs):
 
         kwargs.update(dict(regularisation="minimizeAwTV"))
-        kwargs.update(dict(blocksize=1))
+        if "blocksize" not in kwargs: 
+            kwargs.update(dict(blocksize=1))
+        else:
+            self.blocksize = 1
         if "delta" not in kwargs:
             self.delta = np.array([-0.005], dtype=np.float32)[0]
         ASD_POCS.__init__(self, proj, geo, angles, niter, **kwargs)
@@ -214,7 +217,27 @@ class OS_ASD_POCS(ASD_POCS):
 
         if "blocksize" not in kwargs:
             kwargs.update(blocksize=20)
+        else:
+            self.blocksize = kwargs["blocksize"]
         ASD_POCS.__init__(self, proj, geo, angles, niter, **kwargs)
 
 
 os_asd_pocs = decorator(OS_ASD_POCS, name="os_asd_pocs")
+
+
+class OS_AwASD_POCS(ASD_POCS): 
+    __doc__ = ASD_POCS.__doc__
+
+    def __init__(self, proj, geo, angles, niter, **kwargs):
+
+        kwargs.update(dict(regularisation="minimizeAwTV"))
+        if "blocksize" not in kwargs:
+            kwargs.update(dict(blocksize=20))
+        else:
+            self.blocksize = kwargs["blocksize"]
+        if "delta" not in kwargs:
+            self.delta = np.array([-0.005], dtype=np.float32)[0]
+        ASD_POCS.__init__(self, proj, geo, angles, niter, **kwargs)
+
+
+os_awasd_pocs = decorator(AwASD_POCS, name="os_awasd_pocs")

--- a/Python/tigre/utilities/geometry.py
+++ b/Python/tigre/utilities/geometry.py
@@ -133,7 +133,7 @@ class Geometry(object):
         """
         old_attrib = getattr(self, attrib)
 
-        if type(old_attrib) in [float, int, np.float32, np.float64]:
+        if type(old_attrib) in [float, int, np.float32, np.float64, np.int32]:
             new_attrib = matlib.repmat(old_attrib, 1, angles.shape[0])[0]
             setattr(self, attrib, new_attrib)
 


### PR DESCRIPTION
For Python version, corrected a bug that will always set blocksize=1 for OS algorithms in POCS family. Added a "OS" version of AwASD_POCS" algorithm. In current code there is a limitation that number of angles has be be divisible by blocksize (not ideal). The limitation seems from ordered_subsets() function. Older version using "list comprehension" may work here.