### PR TITLE
Fix computeV.m for MATLAB R2016a

### DIFF
--- a/MATLAB/Utilities/computeV.m
+++ b/MATLAB/Utilities/computeV.m
@@ -9,7 +9,7 @@ if ~isfield(geo,'mode')||~strcmp(geo.mode,'parallel')
         auxindex=orig_index{ii};
         auxgeo = geo;
         % expand the detector to avoiding zeros in backprojection
-        maxsize=max(auxgeo.sVoxel+geo.offOrigin(:,auxindex),[],2);
+%         maxsize=max(auxgeo.sVoxel+geo.offOrigin(:,auxindex),[],2);
 %         auxgeo.sDetector=max(auxgeo.sDetector , [maxsize(1); maxsize(3)] *geo.DSD/geo.DSO);
 %         auxgeo.dDetector = auxgeo.sDetector ./ auxgeo.nDetector;
         % subset of projection angles


### PR DESCRIPTION
* See #318
* Tested Conditions
   * Env 1
      * MATLAB R2016a
      * VS2015
      * Windows 10
   * Env 2
      * MATLAB R2021a
      * VS2019
      * Windows 10
   * Common
      * RTX2080Ti x2 + GTX1070 x1
* On both environments, `d04_SimpleReconstruction.m` did not stop in `computeV.m`