### PR TITLE
Refactor python time estimation until completion

### DIFF
--- a/Python/tigre/algorithms/art_family_algorithms.py
+++ b/Python/tigre/algorithms/art_family_algorithms.py
@@ -6,11 +6,6 @@ from tigre.algorithms.iterative_recon_alg import decorator
 from tigre.utilities.im_3d_denoise import im3ddenoise
 
 
-if hasattr(time, "perf_counter"):
-    default_timer = time.perf_counter
-else:
-    default_timer = time.clock
-
 
 class SART(IterativeReconAlg):  # noqa: D101
     __doc__ = (
@@ -93,18 +88,7 @@ class OS_SART_TV(IterativeReconAlg):  # noqa: D101, N801
             if Quameasopts is not None:
                 res_prev = copy.deepcopy(self.res)
             if self.verbose:
-                if i == 0:
-                    print(str(self.name).upper() + " " + "algorithm in progress.")
-                    toc = default_timer()
-                if i == 1:
-                    tic = default_timer()
-
-                    remaining_time = (self.niter - 1) * (tic - toc)
-                    seconds = int(remaining_time)
-                    print(
-                        "Estimated time until completion : "
-                        + time.strftime("%H:%M:%S", time.gmtime(seconds))
-                    )
+                self._estimate_time_until_completion(i)
 
             getattr(self, self.dataminimizing)()
             # print("run_main_iter: gpuids = {}", self.gpuids)

--- a/Python/tigre/algorithms/ista_algorithms.py
+++ b/Python/tigre/algorithms/ista_algorithms.py
@@ -10,11 +10,6 @@ from tigre.algorithms.iterative_recon_alg import decorator
 from tigre.utilities.im_3d_denoise import im3ddenoise
 
 
-if hasattr(time, "perf_counter"):
-    default_timer = time.perf_counter
-else:
-    default_timer = time.clock
-
 
 class FISTA(IterativeReconAlg):
     """
@@ -170,18 +165,8 @@ class FISTA(IterativeReconAlg):
             if Quameasopts is not None:
                 res_prev = copy.deepcopy(self.res)
             if self.verbose:
-                if i == 0:
-                    print(str(self.name).upper() + " " + "algorithm in progress.")
-                    toc = default_timer()
-                if i == 1:
-                    tic = default_timer()
+                self._estimate_time_until_completion(i)
 
-                    remaining_time = (self.niter - 1) * (tic - toc)
-                    seconds = int(remaining_time)
-                    print(
-                        "Estimated time until completion : "
-                        + time.strftime("%H:%M:%S", time.gmtime(seconds))
-                    )
             getattr(self, self.dataminimizing)()
 
             x_rec_old = copy.deepcopy(x_rec)
@@ -215,15 +200,8 @@ class ISTA(FISTA):  # noqa: D101
             if Quameasopts is not None:
                 res_prev = copy.deepcopy(self.res)
             if self.verbose:
-                if i == 0:
-                    print(str(self.name).upper() + " " + "algorithm in progress.")
-                    toc = time.perf_counter()
-                if i == 1:
-                    tic = time.perf_counter()
-                    print(
-                        "Esitmated time until completetion (s): "
-                        + str((self.niter - 1) * (tic - toc))
-                    )
+                self._estimate_time_until_completion(i)
+
             getattr(self, self.dataminimizing)()
 
             self.res = im3ddenoise(self.res, 20, 1.0 / lambdaForTv, self.gpuids)

--- a/Python/tigre/algorithms/iterative_recon_alg.py
+++ b/Python/tigre/algorithms/iterative_recon_alg.py
@@ -199,6 +199,8 @@ class IterativeReconAlg(object):
             self.set_v()
         if not hasattr(self, "res"):
             self.set_res()
+        if self.verbose:
+            self.tic = 0    # preparation for _estimate_time_until_completion()
         # make it list
         if self.Quameasopts is not None:
             self.Quameasopts = (
@@ -313,18 +315,7 @@ class IterativeReconAlg(object):
             if Quameasopts is not None:
                 res_prev = copy.deepcopy(self.res)
             if self.verbose:
-                if i == 0:
-                    print(str(self.name).upper() + " " + "algorithm in progress.")
-                    toc = default_timer()
-                if i == 1:
-                    tic = default_timer()
-
-                    remaining_time = (self.niter - 1) * (tic - toc)
-                    seconds = int(remaining_time)
-                    print(
-                        "Estimated time until completion : "
-                        + time.strftime("%H:%M:%S", time.gmtime(seconds))
-                    )
+                self._estimate_time_until_completion(i)
 
             getattr(self, self.dataminimizing)()
             self.error_measurement(res_prev, i)
@@ -425,6 +416,20 @@ class IterativeReconAlg(object):
                 parameters.append(item + ": " + str(self.__dict__.get(item)))
 
         return "\n".join(parameters)
+
+    def _estimate_time_until_completion(self, iter):
+        if iter == 0:
+            print(str(self.name).upper() + " " + "algorithm in progress.")
+            self.tic = default_timer()
+        if iter == 1:
+            toc = default_timer()
+
+            remaining_time = (self.niter - 1) * (toc - self.tic)
+            seconds = int(remaining_time)
+            print(
+                "Estimated time until completion : "
+                + time.strftime("%H:%M:%S", time.gmtime(seconds))
+            )
 
 
 def decorator(IterativeReconAlg, name=None, docstring=None):  # noqa: N803

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -61,18 +61,8 @@ class CGLS(IterativeReconAlg):  # noqa: D101
         avgtime = []
         for i in range(self.niter):
             if self.verbose:
-                if i == 0:
-                    print("CGLS Algorithm in progress.")
-                    toc = default_timer()
-                if i == 1:
-                    tic = default_timer()
+                self._estimate_time_until_completion(i)
 
-                    remaining_time = (self.niter - 1) * (tic - toc)
-                    seconds = int(remaining_time)
-                    print(
-                        "Estimated time until completion : "
-                        + time.strftime("%H:%M:%S", time.gmtime(seconds))
-                    )
             avgtic = default_timer()
             q = tigre.Ax(self.__p__, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
             q_norm = np.linalg.norm(q)

--- a/Python/tigre/algorithms/pocs_algorithms.py
+++ b/Python/tigre/algorithms/pocs_algorithms.py
@@ -11,10 +11,6 @@ from tigre.utilities.Ax import Ax
 from tigre.utilities.im3Dnorm import im3DNORM
 
 
-if hasattr(time, "perf_counter"):
-    default_timer = time.perf_counter
-else:
-    default_timer = time.clock
 
 
 class ASD_POCS(IterativeReconAlg):  # noqa: N801
@@ -139,18 +135,7 @@ class ASD_POCS(IterativeReconAlg):  # noqa: N801
         n_iter = 0
         while not stop_criteria:
             if self.verbose:
-                if n_iter == 0:
-                    print("POCS Algorithm in progress.")
-                    toc = default_timer()
-                if n_iter == 1:
-                    tic = default_timer()
-
-                    remaining_time = (self.niter - 1) * (tic - toc)
-                    seconds = int(remaining_time)
-                    print(
-                        "Estimated time until completion : "
-                        + time.strftime("%H:%M:%S", time.gmtime(seconds))
-                    )
+                self._estimate_time_until_completion(n_iter)
 
             res_prev = copy.deepcopy(self.res)
             n_iter += 1

--- a/Python/tigre/algorithms/statistical_algorithms.py
+++ b/Python/tigre/algorithms/statistical_algorithms.py
@@ -9,11 +9,6 @@ from tigre.utilities.Atb import Atb
 from tigre.utilities.Ax import Ax
 
 
-if hasattr(time, "perf_counter"):
-    default_timer = time.perf_counter
-else:
-    default_timer = time.clock
-
 
 class MLEM(IterativeReconAlg):  # noqa: D101
     __doc__ = (
@@ -41,20 +36,8 @@ class MLEM(IterativeReconAlg):  # noqa: D101
     def run_main_iter(self):
         self.res[self.res < 0.0] = 0.0
         for i in range(self.niter):
-            if i == 0:
-                if self.verbose:
-                    print("MLEM Algorithm in progress.")
-                toc = default_timer()
-            if i == 1:
-                tic = default_timer()
-                if self.verbose:
-                    print(
-                        "Esitmated time until completetion (s): {:.4f}".format(
-                            (self.niter - 1) * (tic - toc)
-                        )
-                    )
+            self._estimate_time_until_completion(i)
 
-            #            tic = time.process_time()
             den = Ax(self.res, self.geo, self.angles, "interpolated", gpuids=self.gpuids)
             # toc = time.process_time()
             # print('Ax time: {}'.format(toc-tic))


### PR DESCRIPTION
* Refactor time estimation part in run_main_iter.
* Make POCS algos show their own names.

# Motivation
## 1
Despite they have their own names, all POCS algorithms shows like
```
POCS Algorithm in progress.
Estimated time until completion : 00:02:21
```

## 2
Tidy up.

# Tests

Run demos d07, d08, d09, d20 without error.

Especially, d09 (n_iter = 4) showed
```
(dev38) D:\ws\20210907_TIGRE_alg_name\Python>python demos\d09_Algorithms04.py
OSSART algorithm in progress.
Estimated time until completion : 00:00:01
ASD_POCS algorithm in progress.
Estimated time until completion : 00:00:31

     Stop criteria met:
     c = -0.807888
     beta = 0.9996000599960002
     iter = 4

OS_ASD_POCS algorithm in progress.
Estimated time until completion : 00:00:03

     Stop criteria met:
     c = -0.6594117
     beta = 0.9996000599960002
     iter = 4

AWASD_POCS algorithm in progress.
Estimated time until completion : 00:00:31

     Stop criteria met:
     c = -0.24996887
     beta = 0.9996000599960002
     iter = 4
```
