### PR TITLE
Offset redundancy weighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ MATLAB/mex_CUDA_win64.xml
 
 # Miscellaneous
 *.pdf
+*.dcm

--- a/MATLAB/Algorithms/ASD_POCS.m
+++ b/MATLAB/Algorithms/ASD_POCS.m
@@ -1,4 +1,4 @@
-function [ f,qualMeasOut ] = ASD_POCS(proj,geo,angles,maxiter,varargin)
+function [ f,qualMeasOut ] = ASD_POCS(proj,geo,angles,maxiter,redundancy_weights,varargin)
 %ASD_POCS Solves the ASD_POCS total variation constrained image in 3D
 % tomography.
 %
@@ -98,6 +98,17 @@ W=1./W;
 % Back-Projection weigth, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 
 %%
@@ -275,7 +286,7 @@ for ii=1:length(opts)
                 beta=1;
             else
                 if length(val)>1 || ~isnumeric( val)
-                    error('TIGRE:ASD_POCS:InvalidInput','Invalid lambda')
+                    error('CBCT:ASD_POCS:InvalidInput','Invalid lambda')
                 end
                 beta=val;
             end

--- a/MATLAB/Algorithms/AwASD_POCS.m
+++ b/MATLAB/Algorithms/AwASD_POCS.m
@@ -1,4 +1,4 @@
-function [ f,qualMeasOut]= AwASD_POCS(proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [ f,qualMeasOut]= AwASD_POCS(proj,geo,angles,maxiter,varargin)
 %AwASD_POCS Solves the 3D tomography problem using the adaptive-weighted
 %ASD_POCS algorithm which extends from the method ASD_POCS available in the
 %TIGRE toolbox by adding weight equation to better preserve the edge of the
@@ -50,6 +50,9 @@ function [ f,qualMeasOut]= AwASD_POCS(proj,geo,angles,maxiter,redundancy_weights
 %                  'random'  : orders them randomply
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -68,7 +71,7 @@ function [ f,qualMeasOut]= AwASD_POCS(proj,geo,angles,maxiter,redundancy_weights
 
 %% parse inputs
 blocksize=1;
-[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 if measurequality
@@ -224,8 +227,8 @@ end
 
 end
 
-function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'lambda','lambda_red','init','tviter','verbose','alpha','alpha_red','ratio','maxl2err','delta','orderstrategy','qualmeas','nonneg','gpuids'};
+function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'lambda','lambda_red','init','tviter','verbose','alpha','alpha_red','ratio','maxl2err','delta','orderstrategy','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -389,6 +392,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:AwASD_POCS:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in AwASD_POCS()']);

--- a/MATLAB/Algorithms/AwPCSD.m
+++ b/MATLAB/Algorithms/AwPCSD.m
@@ -1,4 +1,4 @@
-function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,maxiter,varargin)
+function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
 %AwPCSD solves the reconstruction problem using adaptive-weighted
 %projection-controlled steepest descent method
 %
@@ -96,6 +96,17 @@ W=1./W;
 % Back-Projection weigth, V
 V=computeV(geo,angles,num2cell(angles),num2cell(1:length(angles)),'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 %Initialize image.
 %f=zeros(geo.nVoxel','single');
 

--- a/MATLAB/Algorithms/AwPCSD.m
+++ b/MATLAB/Algorithms/AwPCSD.m
@@ -1,4 +1,4 @@
-function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,maxiter,varargin)
 %AwPCSD solves the reconstruction problem using adaptive-weighted
 %projection-controlled steepest descent method
 %
@@ -36,6 +36,9 @@ function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,max
 %                  small 'delta' give low weights to almost every pixels,
 %                  making the algorithm inefficient in removing noise or
 %                  straking artifacts. Default is -0.00055
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -53,7 +56,7 @@ function [ f,errorSART,errorTV,errorL2,qualMeasOut] = AwPCSD(proj,geo,angles,max
 % Coded by:           Ander Biguri and Manasavee Lohvithee
 %--------------------------------------------------------------------------
 %% parse inputs
-[beta,beta_red,f,ng,verbose,epsilon,delta,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,epsilon,delta,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 if nargout>1
@@ -248,8 +251,8 @@ end
 end
 
 
-function [beta,beta_red,f0,ng,verbose,epsilon,delta,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','delta','qualmeas','nonneg','gpuids'};
+function [beta,beta_red,f0,ng,verbose,epsilon,delta,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','delta','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -383,6 +386,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:AwPCSD:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in AwPCSD()']);

--- a/MATLAB/Algorithms/B_ASD_POCS_beta.m
+++ b/MATLAB/Algorithms/B_ASD_POCS_beta.m
@@ -1,4 +1,4 @@
-function [ fres, qualMeasOut ] = B_ASD_POCS_beta(proj,geo,angles,maxiter,varargin)
+function [ fres, qualMeasOut ] = B_ASD_POCS_beta(proj,geo,angles,maxiter,redundancy_weights,varargin)
 
 % B_ASD_POCS_beta Solves the ASD_POCS total variation constrained image in 3D
 % tomography using bregman iteration for the data.
@@ -114,6 +114,17 @@ W=1./W;
 
 % Back-Projection weigth, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 clear A x y dx dz;
 

--- a/MATLAB/Algorithms/CGLS.m
+++ b/MATLAB/Algorithms/CGLS.m
@@ -1,4 +1,4 @@
-function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,varargin)
+function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,redundancy_weights,varargin)
 % CGLS_CBCT solves the CBCT problem using the conjugate gradient least
 % squares
 % 
@@ -44,10 +44,25 @@ measurequality=~isempty(QualMeasOpts);
 
 qualMeasOut=zeros(length(QualMeasOpts),niter);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+end
+
 % //doi: 10.1088/0031-9155/56/13/004
 
 r=proj-Ax(x,geo,angles,'Siddon','gpuids',gpuids);
-p=Atb(r,geo,angles,'matched','gpuids',gpuids);
+if redundancy_weights
+    p=Atb(W_r .* r,geo,angles,'matched','gpuids',gpuids);
+else
+    p=Atb(r,geo,angles,'matched','gpuids',gpuids);
+end
 gamma=norm(p(:),2)^2;
 
 errorL2=zeros(1,niter);
@@ -77,7 +92,11 @@ for ii=1:niter
     % If step is adecuatem, then continue withg CGLS
     r=r-alpha*q;
     
-    s=Atb(r,geo,angles,'matched','gpuids',gpuids);
+    if redundancy_weights
+        s=Atb(W_r .* r,geo,angles,'matched','gpuids',gpuids);
+    else
+        s=Atb(r,geo,angles,'matched','gpuids',gpuids);
+    end
     gamma1=norm(s(:),2)^2;
     beta=gamma1/gamma;
     gamma=gamma1;

--- a/MATLAB/Algorithms/CGLS.m
+++ b/MATLAB/Algorithms/CGLS.m
@@ -1,4 +1,4 @@
-function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,redundancy_weights,varargin)
+function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,varargin)
 % CGLS_CBCT solves the CBCT problem using the conjugate gradient least
 % squares
 % 
@@ -20,6 +20,9 @@ function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,redundancy_weights,
 %                            image. Not recomended unless you really
 %                            know what you are doing.
 %  'InitImg'    an image for the 'image' initialization. Avoid.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -39,7 +42,7 @@ function [x,errorL2,qualMeasOut]= CGLS(proj,geo,angles,niter,redundancy_weights,
 
 %%
 
-[verbose,x,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[verbose,x,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 qualMeasOut=zeros(length(QualMeasOpts),niter);
@@ -116,8 +119,8 @@ end
 
 
 %% parse inputs'
-function [verbose,x,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'init','initimg','verbose','qualmeas','gpuids'};
+function [verbose,x,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'init','initimg','verbose','qualmeas','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 
 % Check inputs
@@ -212,6 +215,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise 
             error('TIGRE:CGLS:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in CGLS()']);

--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -219,7 +219,7 @@ for ii=1:length(opts)
         case 'parker'
             if default
                 if size(angles,1)==1 || (all(angles(2,:)==0) && all(angles(3,:)==0))
-                    parker=max(angles)-min(angles)<(2*pi-max(diff(angles)));
+                    parker=max(angles(1,:))-min(angles(1,:))<(2*pi-max(diff(angles(1,:))));
                 else
                     parker=false;
                 end

--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -38,22 +38,19 @@ function [res]=FDK(proj,geo,angles,varargin)
 % Codes:              https://github.com/CERN/TIGRE/
 % Coded by:           Kyungsang Kim, modified by Ander Biguri, Brandon Nelson 
 %--------------------------------------------------------------------------
-[filter,parker,dowang,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[filter,parker,gpuids]=parse_inputs(proj,geo,angles,varargin);
 
 geo=checkGeo(geo,angles);
 geo.filter=filter;
 
-if dowang
-    disp('FDK: applying detector offset weights')
-    % Zero-padding to avoid FFT-induced aliasing
-    [zproj, zgeo, theta] = zeropadding(proj, geo);
-    % Preweighting using Wang function to save memory
-    [proj, ~] = preweighting2(zproj, zgeo, theta);
-    
-    %% Replace original proj and geo
-    % proj = proj_w;
-    geo = zgeo;
-end
+% Zero-padding to avoid FFT-induced aliasing %TODO: should't this be
+% for all cases, not just wang?
+[zproj, zgeo] = zeropadding(proj, geo);
+% Preweighting using Wang function
+proj=zproj.*redundancy_weighting(zgeo);
+% Replace original proj and geo
+% proj = proj_w;
+geo = zgeo;
 
 if size(geo.offDetector,2)==1
     offset=repmat(geo.offDetector,[1 size(angles,2)]);
@@ -90,7 +87,7 @@ res=Atb((proj),geo,angles, 'gpuids', gpuids); % Weighting is inside
 
 end
 
-function [zproj, zgeo, theta] = zeropadding(proj, geo)
+function [zproj, zgeo] = zeropadding(proj, geo)
 % ZEROPADDING as preprocessing for preweighting
 zgeo = geo;
 
@@ -117,72 +114,10 @@ end
 
 end
 
-function [proj_w, w] = preweighting(proj,geo,theta)
-% Preweighting using Wang function
-% Ref: 
-%    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
-offset = geo.offDetector(1);
-offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);
-us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
 
-abstheta=abs(theta);
+function [filter, parker, gpuids]=parse_inputs(proj,geo,angles,argin)
 
-w = ones(size(proj(:,:,1)));
-for ii = 1:geo.nDetector
-    t = us(ii);
-    if(abs(t) <= abstheta)
-        w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(theta/geo.DSO(1)))) + 1);
-    end
-    if(t<-abstheta)
-        w(:,ii) = 0;
-    end
-end
-
-if(theta<0)
-    w = fliplr(w);
-end
-
-for ii = 1:size(proj,3)
-    proj_w(:,:,ii) = proj(:,:,ii).*w*2;
-end
-
-end
-function [proj_w, w] = preweighting2(proj,geo,theta)
-% Preweighting using Wang function
-% Ref: 
-%    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
-offset = geo.offDetector(1);
-offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
-us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
-
-us = us * geo.DSO(1)/geo.DSD(1);
-abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
-
-w = ones(size(proj(:,:,1)));
-
-for ii = 1:geo.nDetector
-    t = us(ii);
-    if(abs(t) <= abstheta)
-        w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(abstheta/geo.DSO(1)))) + 1);
-    end
-    if(t<-abstheta)
-        w(:,ii) = 0;
-    end
-end
-
-if(theta<0)
-    w = fliplr(w);
-end
-proj_w=proj;% preallocation
-for ii = 1:size(proj,3)
-    proj_w(:,:,ii) = proj(:,:,ii).*w*2;
-end
-
-end
-
-function [filter, parker,wang, gpuids]=parse_inputs(proj,geo,angles,argin)
-
-opts =  {'filter','parker','wang', 'gpuids'};
+opts =  {'filter','parker', 'gpuids'};
 defaults=ones(length(opts),1);
 
 % Check inputs
@@ -226,14 +161,6 @@ for ii=1:length(opts)
             else
                 parker=val;
             end
-        case 'wang'
-            if default
-                wang=apply_wang_weights(geo);
-            else
-                wang=val;
-            end
-                    
-  
         case 'filter'
             if default
                 filter='ram-lak';
@@ -254,31 +181,4 @@ for ii=1:length(opts)
             error('CBCT:FDK:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in FDK()']);
     end
 end
-end
-
-
-function bool = apply_wang_weights(geo)
-    if (size(geo.offDetector,2) > 1) && length(unique(geo.offDetector(1,:)))>1
-        warning('FDK Wang weights: varying offDetector detected, Wang weights not being applied');
-        bool = false;
-        return
-    end
-    
-    if geo.offDetector(1) == 0
-        bool = false;
-        return
-    end
-    
-    if (numel(geo.DSO) > 1) && (length(unique(geo.DSO))>1)
-        warning('FDK Wang weights: varying DSO detected, Wang weights not being applied');
-        bool = false;
-        return
-    end
-
-    percent_offset = abs(geo.offDetector(1)/geo.sDetector(1)) * 100;    
-    if percent_offset > 30
-        warning('FDK Wang weights: Detector offset percent: %0.2f is greater than 30 which may result in image artifacts, consider rebinning 360 degree projections to 180 degrees', percent_offset)
-    end
-    
-    bool = true;
 end

--- a/MATLAB/Algorithms/FISTA.m
+++ b/MATLAB/Algorithms/FISTA.m
@@ -1,4 +1,4 @@
-function [res,qualMeasOut] = FISTA(proj,geo,angles,niter,redundancy_weights,varargin)
+function [res,qualMeasOut] = FISTA(proj,geo,angles,niter,varargin)
 % FISTA is a quadratically converging algorithm, modified from FISTA.
 %
 % It is based on the lazy-start FISTA modification in the following work:
@@ -29,6 +29,9 @@ function [res,qualMeasOut] = FISTA(proj,geo,angles,niter,redundancy_weights,vara
 %                parameters. Input should contain a cell array of desired
 %                quality measurement names. Example: {'CC','RMSE','MSSIM'}
 %                These will be computed in each iteration.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
@@ -46,7 +49,7 @@ function [res,qualMeasOut] = FISTA(proj,geo,angles,niter,redundancy_weights,vara
 % Codes:              https://github.com/CERN/TIGRE/
 % Coded by:           Ander Biguri, Reuben Lindroos
 %--------------------------------------------------------------------------
-[verbose,res,tviter,hyper,lambda,p,q,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[verbose,res,tviter,hyper,lambda,p,q,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 %res = zeros(geo.nVoxel','single');
 measurequality=~isempty(QualMeasOpts);
 
@@ -102,8 +105,8 @@ end
 
 end
 %% Parse inputs
-function [verbose,f0,tviter,hyper,lambda,fista_p,fista_q,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts = {'lambda','init','tviter','verbose','hyper','fista_p','fista_q','qualmeas','gpuids'};
+function [verbose,f0,tviter,hyper,lambda,fista_p,fista_q,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts = {'lambda','init','tviter','verbose','hyper','fista_p','fista_q','qualmeas','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -229,6 +232,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:FISTA:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in FISTA()']);

--- a/MATLAB/Algorithms/OS_ASD_POCS.m
+++ b/MATLAB/Algorithms/OS_ASD_POCS.m
@@ -1,4 +1,4 @@
-function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,varargin)
 %ASD_POCS Solves theOS_ASD_POCS total variation constrained image in 3D
 % tomography.
 %
@@ -52,6 +52,9 @@ function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,redundancy
 %
 %   'Verbose'      1 or 0. Default is 1. Gives information about the
 %                  progress of the algorithm.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -70,7 +73,7 @@ function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,redundancy
 %--------------------------------------------------------------------------
 
 %% parse inputs
-[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,blocksize,OrderStrategy,nonneg,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,blocksize,OrderStrategy,nonneg,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 % first order the projection angles
@@ -232,9 +235,9 @@ end
 
 end
 
-function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,block_size,OrderStrategy,nonneg,QualMeasOpts,gpuids]=parse_inputs(proj,geo,angles,argin)
+function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,block_size,OrderStrategy,nonneg,QualMeasOpts,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
 
-opts=     {'lambda','lambda_red','init','initimg','tviter','verbose','alpha','alpha_red','ratio','maxl2err','blocksize','orderstrategy','blocksize','nonneg','qualmeas','gpuids'};
+opts=     {'lambda','lambda_red','init','initimg','tviter','verbose','alpha','alpha_red','ratio','maxl2err','blocksize','orderstrategy','blocksize','nonneg','qualmeas','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -418,6 +421,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:OS_ASD_POCS:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option']);

--- a/MATLAB/Algorithms/OS_ASD_POCS.m
+++ b/MATLAB/Algorithms/OS_ASD_POCS.m
@@ -1,4 +1,4 @@
-function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,varargin)
+function [ fres, qualMeasOut ] = OS_ASD_POCS (proj,geo,angles,maxiter,redundancy_weights,varargin)
 %ASD_POCS Solves theOS_ASD_POCS total variation constrained image in 3D
 % tomography.
 %
@@ -99,6 +99,17 @@ W=1./W;
 
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 qualMeasOut=zeros(length(QualMeasOpts),maxiter);
 

--- a/MATLAB/Algorithms/OS_AwASD_POCS.m
+++ b/MATLAB/Algorithms/OS_AwASD_POCS.m
@@ -1,4 +1,4 @@
-function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,varargin)
+function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,redundancy_weights,varargin)
 %OS_AwASD_POCS Solves the 3D tomography problem using the adaptive-weighted
 %OS_ASD_POCS algorithm which extends from the method OS_ASD_POCS available in the
 %TIGRE toolbox by adding weight equation to better preserve the edge of the
@@ -82,6 +82,8 @@ if ~isfield(geo,'rotDetector')
     geo.rotDetector=[0;0;0];
 end
 
+%[proj,geo] = doOffsetWang(proj,geo);
+
 %% Create weigthing matrices for the SART step
 % the reason we do this, instead of calling the SART fucntion is not to
 % recompute the weigths every AwASD-POCS iteration, thus effectively doubling
@@ -101,6 +103,17 @@ W=1./W;
 % Back-Projection weight, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 if measurequality
     qualMeasOut=zeros(length(QualMeasOpts),maxiter);
@@ -332,7 +345,7 @@ for ii=1:length(opts)
         %  =========================================================================
         case 'maxl2err'
             if default
-                epsilon=im3Dnorm(FDK(proj,geo,angles))*0.2; %heuristic
+                epsilon=im3Dnorm(FDK(proj,geo,angles),'L2')*0.2; %heuristic
             else
                 epsilon=val;
             end

--- a/MATLAB/Algorithms/OS_AwASD_POCS.m
+++ b/MATLAB/Algorithms/OS_AwASD_POCS.m
@@ -1,4 +1,4 @@
-function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,varargin)
 %OS_AwASD_POCS Solves the 3D tomography problem using the adaptive-weighted
 %OS_ASD_POCS algorithm which extends from the method OS_ASD_POCS available in the
 %TIGRE toolbox by adding weight equation to better preserve the edge of the
@@ -56,6 +56,9 @@ function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,redundancy_weigh
 %                  'random'  : orders them randomply
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -73,7 +76,7 @@ function [f,qualMeasOut]= OS_AwASD_POCS(proj,geo,angles,maxiter,redundancy_weigh
 % Coded by:           Ander Biguri and Manasavee Lohvithee
 
 %% parse inputs
-[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,blocksize,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,blocksize,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 [alphablocks,orig_index]=order_subsets(angles,blocksize,OrderStrategy);
@@ -227,8 +230,8 @@ end
 
 end
 
-function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,block_size,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'lambda','lambda_red','init','tviter','verbose','alpha','alpha_red','ratio','maxl2err','delta','blocksize','orderstrategy','qualmeas','nonneg','gpuids'};
+function [beta,beta_red,f0,ng,verbose,alpha,alpha_red,rmax,epsilon,delta,block_size,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'lambda','lambda_red','init','tviter','verbose','alpha','alpha_red','ratio','maxl2err','delta','blocksize','orderstrategy','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -400,6 +403,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:OS_AwASD_POCS:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in OS_AwASD_POCS()']);

--- a/MATLAB/Algorithms/OS_AwPCSD.m
+++ b/MATLAB/Algorithms/OS_AwPCSD.m
@@ -1,4 +1,4 @@
-function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,maxiter,varargin)
+function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
 %OS_AwPCSD solves the reconstruction problem using adaptive-weighted
 %projection-controlled steepest descent method
 %
@@ -113,6 +113,17 @@ W=1./W;
 % Back-Projection weigth, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 iter=0;
 offOrigin=geo.offOrigin;
@@ -347,7 +358,7 @@ for ii=1:length(opts)
         %  =========================================================================
         case 'maxl2err'
             if default
-                epsilon=im3Dnorm(FDK(proj,geo,angles))*0.2; %heuristic
+                epsilon=im3Dnorm(FDK(proj,geo,angles),'L2')*0.2; %heuristic
             else
                 epsilon=val;
             end

--- a/MATLAB/Algorithms/OS_AwPCSD.m
+++ b/MATLAB/Algorithms/OS_AwPCSD.m
@@ -1,4 +1,4 @@
-function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,maxiter,varargin)
 %OS_AwPCSD solves the reconstruction problem using adaptive-weighted
 %projection-controlled steepest descent method
 %
@@ -48,6 +48,9 @@ function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,
 %                  'random'  : orders them randomply
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -65,7 +68,7 @@ function [ f,errorSART,errorTV,errorL2,qualMeasOut] = OS_AwPCSD(proj,geo,angles,
 % Coded by:           Ander Biguri and Manasavee Lohvithee
 %--------------------------------------------------------------------------
 %% parse inputs
-[beta,beta_red,f,ng,verbose,epsilon,delta,blocksize,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,epsilon,delta,blocksize,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 
 measurequality=~isempty(QualMeasOpts);
 
@@ -263,8 +266,8 @@ end
 end
 
 
-function [beta,beta_red,f0,ng,verbose,epsilon,delta,block_size,OrderStrategy,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','delta','blocksize','orderstrategy','qualmeas','nonneg','gpuids'};
+function [beta,beta_red,f0,ng,verbose,epsilon,delta,block_size,OrderStrategy,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','delta','blocksize','orderstrategy','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -420,6 +423,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:OS_AwPCSD:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in OS_AwPCSD()']);

--- a/MATLAB/Algorithms/OS_SART.m
+++ b/MATLAB/Algorithms/OS_SART.m
@@ -1,4 +1,4 @@
-function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,redundancy_weights,varargin)
+function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,varargin)
 
 % OS_SART solves Cone Beam CT image reconstruction using Oriented Subsets
 %              Simultaneous Algebraic Reconxtruction Techique algorithm
@@ -41,6 +41,9 @@ function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,redundancy_weig
 %                  'random'  : orders them randomply
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %
 % OUTPUTS:
 %
@@ -69,7 +72,7 @@ function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,redundancy_weig
 
 %% Deal with input parameters
 
-[blocksize,lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg, gpuids]=parse_inputs(proj,geo,angles,varargin);
+[blocksize,lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 measurequality=~isempty(QualMeasOpts);
 
 qualMeasOut=zeros(length(QualMeasOpts),niter);
@@ -275,8 +278,8 @@ end
 end
 
 %% Parse inputs
-function [block_size,lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'blocksize','lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids'};
+function [block_size,lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,alpha,argin)
+opts=     {'blocksize','lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -413,7 +416,12 @@ for ii=1:length(opts)
             else
                 gpuids = val;
             end
-
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
+            end
         otherwise
             error('TIGRE:OS_SART:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in OS_SART_CBCT()']);
     end

--- a/MATLAB/Algorithms/PCSD.m
+++ b/MATLAB/Algorithms/PCSD.m
@@ -1,4 +1,4 @@
-function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
+function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,varargin)
 %PCSD solves the reconstruction problem using projection-controlled steepest descent method
 %
 %   PCSD(PROJ,GEO,ALPHA,NITER) solves the reconstruction problem using
@@ -28,6 +28,9 @@ function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,redundancy_weights,vara
 %                  Default is 20% of the FDK L2 norm.
 %   'Verbose'      1 or 0. Default is 1. Gives information about the
 %                  progress of the algorithm.
+% 'redundancy_weighting': true or false. Default is true. Applies data
+%                         redundancy weighting to projections in the update step
+%                         (relevant for offset detector geometry)
 %--------------------------------------------------------------------------
 %--------------------------------------------------------------------------
 % This file is part of the TIGRE Toolbox
@@ -46,7 +49,7 @@ function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,redundancy_weights,vara
 %--------------------------------------------------------------------------
 
 %% parse inputs
-[beta,beta_red,f,ng,verbose,epsilon,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[beta,beta_red,f,ng,verbose,epsilon,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,varargin);
 
 measurequality=~isempty(QualMeasOpts);
 
@@ -205,8 +208,8 @@ end
 end
 
 
-function [beta,beta_red,f0,ng,verbose,epsilon,QualMeasOpts,nonneg,gpuids]=parse_inputs(proj,geo,angles,argin)
-opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','qualmeas','nonneg','gpuids'};
+function [beta,beta_red,f0,ng,verbose,epsilon,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,angles,argin)
+opts=     {'lambda','lambda_red','init','tviter','verbose','maxl2err','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -331,6 +334,12 @@ for ii=1:length(opts)
                 gpuids = GpuIds();
             else
                 gpuids = val;
+            end
+        case 'redundancy_weighting'
+            if default
+                redundancy_weights = true;
+            else
+                redundancy_weights = val;
             end
         otherwise
             error('TIGRE:PCSD:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in PCSD()']);

--- a/MATLAB/Algorithms/PCSD.m
+++ b/MATLAB/Algorithms/PCSD.m
@@ -1,4 +1,4 @@
-function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,varargin)
+function [ f,qualMeasOut] = PCSD(proj,geo,angles,maxiter,redundancy_weights,varargin)
 %PCSD solves the reconstruction problem using projection-controlled steepest descent method
 %
 %   PCSD(PROJ,GEO,ALPHA,NITER) solves the reconstruction problem using
@@ -77,6 +77,17 @@ W=1./W;
 % Compute V
 V=computeV(geo,angles,num2cell(angles),num2cell(1:length(angles)),'gpuids',gpuids);
 
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 %Initialize image.
 %f=zeros(geo.nVoxel','single');

--- a/MATLAB/Algorithms/SART.m
+++ b/MATLAB/Algorithms/SART.m
@@ -1,4 +1,4 @@
-function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
+function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,redundancy_weights,varargin)
 %SART solves Cone Beam CT image reconstruction using Oriented Subsets
 %              Simultaneous Algebraic Reconxtruction Techique algorithm
 %
@@ -90,6 +90,18 @@ W(W>0.1)=0.1;
 
 % Back-Projection weigth, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
+
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 clear A x y dx dz;
 %% hyperparameter stuff

--- a/MATLAB/Algorithms/SART_TV.m
+++ b/MATLAB/Algorithms/SART_TV.m
@@ -1,4 +1,4 @@
-function [res,errorL2,qualMeasOut]=SART_TV(proj,geo,angles,niter,varargin)
+function [res,errorL2,qualMeasOut]=SART_TV(proj,geo,angles,niter,redundancy_weights,varargin)
 % SART_TV solves Cone Beam CT image reconstruction using Oriented Subsets
 %              Simultaneous Algebraic Reconxtruction Techique algorithm
 %
@@ -95,6 +95,18 @@ W(W<min(geo.dVoxel)/4)=Inf;
 W=1./W;
 % Back-Projection weigth, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
+
+if redundancy_weights
+    % Data redundancy weighting, W_r implemented using Wang weighting
+    % reference: https://iopscience.iop.org/article/10.1088/1361-6560/ac16bc
+    
+    num_frames = size(proj,3);
+    W_r = redundancy_weighting(geo);
+    W_r = repmat(W_r,[1,1,num_frames]);
+    % disp('Size of redundancy weighting matrix');
+    % disp(size(W_r));
+    W = W.*W_r; % include redundancy weighting in W
+end
 
 %% Iterate
 offOrigin=geo.offOrigin;

--- a/MATLAB/Utilities/apply_wang_weights.m
+++ b/MATLAB/Utilities/apply_wang_weights.m
@@ -1,0 +1,25 @@
+function bool = apply_wang_weights(geo)
+    if (size(geo.offDetector,2) > 1) && length(unique(geo.offDetector(1,:)))>1
+        warning('Wang weights: varying offDetector detected, Wang weights not being applied');
+        bool = false;
+        return
+    end
+    
+    if geo.offDetector(1) == 0
+        bool = false;
+        return
+    end
+    
+    if (numel(geo.DSO) > 1) && (length(unique(geo.DSO))>1)
+        warning('Wang weights: varying DSO detected, Wang weights not being applied');
+        bool = false;
+        return
+    end
+
+    percent_offset = abs(geo.offDetector(1)/geo.sDetector(1)) * 100;    
+    if percent_offset > 30
+        warning('Wang weights: Detector offset percent: %0.2f is greater than 30 which may result in image artifacts, consider rebinning 360 degree projections to 180 degrees', percent_offset)
+    end
+    
+    bool = true;
+end

--- a/MATLAB/Utilities/computeV.m
+++ b/MATLAB/Utilities/computeV.m
@@ -8,6 +8,7 @@ else
 end
     
 V=zeros(geo.nVoxel(1),geo.nVoxel(2) ,length(alphablocks),'single');
+%geo.offDetector(1) = geo.offDetector(1) + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);  
 geo=checkGeo(geo,angles);
 
 if ~isfield(geo,'mode')||~strcmp(geo.mode,'parallel')
@@ -16,9 +17,9 @@ if ~isfield(geo,'mode')||~strcmp(geo.mode,'parallel')
         auxindex=orig_index{ii};
         auxgeo = geo;
         % expand the detector to avoiding zeros in backprojection
-%         maxsize=max(auxgeo.sVoxel+geo.offOrigin(:,auxindex),[],2);
-%         auxgeo.sDetector=max(auxgeo.sDetector , [maxsize(1); maxsize(3)] *geo.DSD/geo.DSO);
-%         auxgeo.dDetector = auxgeo.sDetector ./ auxgeo.nDetector;
+        maxsize=max(auxgeo.sVoxel+geo.offOrigin(:,auxindex),[],2);
+        auxgeo.sDetector=max(auxgeo.sDetector , [maxsize(1); maxsize(3)] *geo.DSD/geo.DSO);
+        auxgeo.dDetector = auxgeo.sDetector ./ auxgeo.nDetector;
         % subset of projection angles
         auxgeo.DSD = geo.DSD(auxindex);
         auxgeo.DSO = geo.DSO(auxindex);

--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -2,6 +2,10 @@ function w = redundancy_weighting(geo)
 % Preweighting using Wang function
 % Ref: 
 %    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
+
+if ~isfield(geo,'COR')
+    geo.COR=0;
+end
 offset = geo.offDetector(1);
 offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
 us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
@@ -12,18 +16,19 @@ theta = (geo.sDetector(1)/2 - abs(offset))...
 abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
 
 w = ones([geo.nDetector(2),geo.nDetector(1)]);
-
-for ii = 1:geo.nDetector
-    t = us(ii);
-    if(abs(t) <= abstheta)
-        w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(abstheta/geo.DSO(1)))) + 1);
+if apply_wang_weights(geo)
+    for ii = 1:geo.nDetector
+        t = us(ii);
+        if(abs(t) <= abstheta)
+            w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(abstheta/geo.DSO(1)))) + 1);
+        end
+        if(t<-abstheta)
+            w(:,ii) = 0;
+        end
     end
-    if(t<-abstheta)
-        w(:,ii) = 0;
+    w=w*2;
+    if(theta<0)
+        w = fliplr(w);
     end
-end
-
-if(theta<0)
-    w = fliplr(w);
 end
 end

--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -1,0 +1,29 @@
+function w = redundancy_weighting(geo)
+% Preweighting using Wang function
+% Ref: 
+%    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
+offset = geo.offDetector(1);
+offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
+us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
+
+us = us * geo.DSO(1)/geo.DSD(1);
+theta = (geo.sDetector(1)/2 - abs(offset))...
+        * sign(offset);
+abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
+
+w = ones([geo.nDetector(2),geo.nDetector(1)]);
+
+for ii = 1:geo.nDetector
+    t = us(ii);
+    if(abs(t) <= abstheta)
+        w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(abstheta/geo.DSO(1)))) + 1);
+    end
+    if(t<-abstheta)
+        w(:,ii) = 0;
+    end
+end
+
+if(theta<0)
+    w = fliplr(w);
+end
+end


### PR DESCRIPTION
Added data redundancy weighting necessary for offset detector geometry (as an option) in all algorithms, except MLEM, tested with simulation & real data..
also includes 
- fix in V matrix for more stability
- additional fix in zeropadding function for geo.COR
