### PR TITLE
do_3d_projection method in Arrow3D

### DIFF
--- a/Python/tigre/utilities/visualization/plot_geometry.py
+++ b/Python/tigre/utilities/visualization/plot_geometry.py
@@ -19,6 +19,13 @@ class Arrow3D(matplotlib.patches.FancyArrowPatch):
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         matplotlib.patches.FancyArrowPatch.draw(self, renderer)
 
+    def do_3d_projection(self, render=None):
+        from mpl_toolkits.mplot3d import proj3d
+        xs3d, ys3d, zs3d = self._verts3d
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
+        return np.min(zs)
+
 
 ROT_DEFAULT = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 TRANS_DEFAULT = np.array([0, 0, 0])


### PR DESCRIPTION
Added do_3d_projection method in Arrow3D inside plot_geometry.py. 
source:  https://github.com/matplotlib/matplotlib/issues/21688