### PR TITLE
Improve python installation guide

### DIFF
--- a/Frontispiece/python_installation.md
+++ b/Frontispiece/python_installation.md
@@ -45,6 +45,7 @@ A succesfull installation should be able to execute the script at `TIGRE/Python/
 5. Compile libraries
 
 	`cd TIGRE/Python/`  
+	`pip install -r requirements.txt`  
 	`python setup.py install --user`
 
 	Install in this case will make a copy of pytigre to your python distribution. Therefore the `develop` command is more useful when modifying the source files and developing the software. 
@@ -113,6 +114,7 @@ For Ubuntu
 5. Compile libraries
 
 	`cd TIGRE/Python/` 
+	`pip install -r requirements.txt`  
 	`python setup.py install --user`
 
 	Install in this case will make a copy of pytigre to your python distribution. Therefore the `develop` command is more useful when modifying the source files and developing the software. 

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -2,3 +2,4 @@ Cython
 matplotlib
 numpy
 scipy
+setuptools


### PR DESCRIPTION
- add `setuptools` to Python/requirements.txt 
- add `pip install -r requirements.txt` to the compilation guide.

There are packages that are required to compile TIGRE (ex> `Cython`, `setuptools`).
You should install them before you execute `setup.py` or you'll get the import error.