### PR TITLE
fix the DLL import issue on python 3.8 or higher on windows

### DIFF
--- a/Frontispiece/python_installation.md
+++ b/Frontispiece/python_installation.md
@@ -54,10 +54,6 @@ A succesfull installation should be able to execute the script at `TIGRE/Python/
 
 6. Try demo 3. If it runs succesfully then you are good to go.
 
-**Note:** It is known that the package cannot be imported using a pure Python 3.8 installation, i.e.
-not using a conda environment. Please try a pure installation of Python 3.7 or consider using a
-conda environment.
-
 ## Linux
 
 ### Requirements:

--- a/Python/tigre/__init__.py
+++ b/Python/tigre/__init__.py
@@ -1,4 +1,23 @@
 from __future__ import division, absolute_import, print_function
+
+# fix for DLL import issue on python 3.8 or higher on windows
+# related to: 
+# https://github.com/CERN/TIGRE/issues/247
+# https://github.com/CERN/TIGRE/issues/349
+import os
+
+if hasattr(os, "add_dll_directory"):
+    # Add all the DLL directories manually
+    # see:
+    # https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
+    # https://stackoverflow.com/a/60803169/19344391
+    dll_directory = os.path.dirname(__file__)
+    os.add_dll_directory(dll_directory)
+
+    # The user must install the CUDA Toolkit
+    cuda_bin = os.path.join(os.environ["CUDA_PATH"], "bin")
+    os.add_dll_directory(cuda_bin)
+
 from .utilities.geometry import geometry
 from .utilities.geometry_default import ConeGeometryDefault as geometry_default
 from .utilities.Ax import Ax


### PR DESCRIPTION
Related to #247  #349
Tested on python 3.9.2 & windows 10 / windows 11 
