### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,7 @@ Python/purge.sh
 Python/.idea/
 Python/devtest.py
 Python/dist/
-Python/tigre/utilities/cuda_interface/_Atb.cpp
-Python/tigre/utilities/cuda_interface/_Ax.cpp
-Python/tigre/utilities/cuda_interface/_minTV.cpp
-Python/tigre/utilities/cuda_interface/_AwminTV.cpp
-Python/tigre/utilities/cuda_interface/_tvdenoising.cpp
-Python/tigre/utilities/cuda_interface/_gpuUtils.cpp
+Python/tigre/utilities/cuda_interface/*.cpp
 .ipynb_checkpoints
 # Object files
 *.o


### PR DESCRIPTION
I found that `Python/tigre/utilities/cuda_interface/_randomNumberGenerator.cpp` was not included in `.gitignore` .
So I checked the `.gitignore` file and updated it.

Now, all the .cpp files in `cuda_interface`, including `_randomNumberGenerator.cpp`, are added to `.gitignore`.
So you don't have to edit `.gitignore` any more even if any other new .cpp files are added in the future.