### PR TITLE
Fix numpy memory order issue

### DIFF
--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,5 +1,5 @@
 Cython
 matplotlib
-numpy
+numpy>=1.20.0
 scipy
 setuptools

--- a/Python/tigre/utilities/cuda_interface/_Atb.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Atb.pyx
@@ -38,6 +38,8 @@ def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[
 
     cdef c_Geometry* c_geometry = convert_to_c_geometry(geometry, total_projections)
 
+    angles = np.ascontiguousarray(angles)
+
     cdef float* c_model = <float*> malloc(geometry.nVoxel[0] * geometry.nVoxel[1] * geometry.nVoxel[2] * sizeof(float))
     cdef float* c_angles = <float*> angles.data
 
@@ -57,6 +59,8 @@ def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[
     else:
         print("Warning: Unknown mode, using default cone beam")
         cone_beam = True
+        
+    projections = np.ascontiguousarray(projections)
 
     cdef float* c_projections = <float*> projections.data
 

--- a/Python/tigre/utilities/cuda_interface/_AwminTV.pyx
+++ b/Python/tigre/utilities/cuda_interface/_AwminTV.pyx
@@ -48,6 +48,8 @@ def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter 
     imgsize[1] = <long> size_img[1]
     imgsize[2] = <long> size_img[0]
 
+    src = np.ascontiguousarray(src)
+
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
     aw_pocs_tv(c_src, c_imgout, alpha, imgsize, c_maxiter, delta, c_gpuids[0])

--- a/Python/tigre/utilities/cuda_interface/_Ax.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Ax.pyx
@@ -34,7 +34,6 @@ def _Ax_ext(np.ndarray[np.float32_t, ndim=3] img, geometry, np.ndarray[np.float3
     if not c_gpuids:
         raise MemoryError()
     
-
     cdef int total_projections = angles.shape[0]
     cdef int nDetectorPixels = <int>geometry.nDetector[0] * <int>geometry.nDetector[1]
 
@@ -50,6 +49,8 @@ def _Ax_ext(np.ndarray[np.float32_t, ndim=3] img, geometry, np.ndarray[np.float3
     cdef int i = 0
     for i in range(total_projections):
         c_projections[i] = <float*> &(c_projectionsNonPinned[nDetectorPixels * i])
+
+    angles = np.ascontiguousarray(angles)
 
     cdef float* c_angles = <float*> angles.data
     if not c_angles:
@@ -69,6 +70,8 @@ def _Ax_ext(np.ndarray[np.float32_t, ndim=3] img, geometry, np.ndarray[np.float3
     else:
         print("Warning: Unknown mode, using default cone beam")
         cone_beam = True
+
+    img = np.ascontiguousarray(img)
 
     cdef float* c_img = <float*> img.data
     if cone_beam:

--- a/Python/tigre/utilities/cuda_interface/_minTV.pyx
+++ b/Python/tigre/utilities/cuda_interface/_minTV.pyx
@@ -52,6 +52,8 @@ def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 
     imgsize[0] = <long> size_img[2]
     imgsize[1] = <long> size_img[1]
     imgsize[2] = <long> size_img[0]
+    
+    src = np.ascontiguousarray(src)
 
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter

--- a/Python/tigre/utilities/cuda_interface/_randomNumberGenerator.pyx
+++ b/Python/tigre/utilities/cuda_interface/_randomNumberGenerator.pyx
@@ -52,6 +52,8 @@ def add_poisson(np.ndarray[np.float32_t, ndim=3] src, gpuids=None):
     imgsize[1] = <long> size_img[1]
     imgsize[2] = <long> size_img[0]
 
+    src = np.ascontiguousarray(src)
+
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_uiSigLen = <np.npy_intp> (size_img[0] *size_img[1] *size_img[2])
     cuda_raise_errors(poisson_1d(c_src, c_uiSigLen, c_imgout, c_gpuids[0]))
@@ -80,6 +82,8 @@ def add_noise(np.ndarray[np.float32_t, ndim=3] poisson_lambda,
     imgsize[0] = <long> size_img[2]
     imgsize[1] = <long> size_img[1]
     imgsize[2] = <long> size_img[0]
+
+    poisson_lambda = np.ascontiguousarray(poisson_lambda)
 
     cdef float* c_src = <float*> poisson_lambda.data
     cdef np.npy_intp c_uiSigLen = <np.npy_intp> (size_img[0] *size_img[1] *size_img[2])

--- a/Python/tigre/utilities/cuda_interface/_tvdenoising.pyx
+++ b/Python/tigre/utilities/cuda_interface/_tvdenoising.pyx
@@ -59,6 +59,8 @@ def tvdenoise(np.ndarray[np.float32_t, ndim=3] src, int maxiter = 100, float lam
     imgsize[1] = <long> size_img[1]
     imgsize[2] = <long> size_img[0]
 
+    src = np.ascontiguousarray(src)
+
     cdef float* c_src = <float*> src.data
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
     cuda_raise_errors(tvdenoising(c_src, c_imgout, lamda, spacing, imgsize, c_maxiter, c_gpuids[0]))


### PR DESCRIPTION
- fix for #399 (not only `Ax`, but also all the cuda-numpy interface functions potentially have the same issue.)
- the memory order of the numpy arrays must be c-contiguous
- `numpy.ascontiguousarray` returns a contiguous array. Deep copy only occurs if the memory order is not c-contiguous.

I didn't added it but you can also add warnings when the deep copy occurs by checking `if img.flags['C_CONTIGUOUS']` if you want.