### PR TITLE
Fix bug and typos

### DIFF
--- a/MATLAB/Algorithms/OS_SART.m
+++ b/MATLAB/Algorithms/OS_SART.m
@@ -1,34 +1,33 @@
 function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,varargin)
-
 % OS_SART solves Cone Beam CT image reconstruction using Oriented Subsets
-%              Simultaneous Algebraic Reconxtruction Techique algorithm
+%              Simultaneous Algebraic Reconstruction Technique algorithm
 %
 %   OS_SART(PROJ,GEO,ALPHA,NITER) solves the reconstruction problem
 %   using the projection data PROJ taken over ALPHA angles, corresponding
-%   to the geometry descrived in GEO, using NITER iterations.
+%   to the geometry described in GEO, using NITER iterations.
 %
 %   OS_SART(PROJ,GEO,ALPHA,NITER,OPT,VAL,...) uses options and values for solving. The
 %   possible options in OPT are:
 %
 %   'BlockSize':   Sets the projection block size used simultaneously. If
-%                  BlockSize = 1 OS-SART becomes SART and if  BlockSize = length(alpha)
+%                  BlockSize = 1 OS-SART becomes SART and if BlockSize = length(alpha)
 %                  then OS-SART becomes SIRT. Default is 20.
 %
 %   'lambda':      Sets the value of the hyperparameter. Default is 1
 %
-%   'lambda_red':   Reduction of lambda.Every iteration
+%   'lambda_red':  Reduction of lambda. Every iteration
 %                  lambda=lambdared*lambda. Default is 0.95
 %
-%   'Init':        Describes diferent initialization techniques.
+%   'Init':        Describes different initialization techniques.
 %                  'none'     : Initializes the image to zeros (default)
-%                  'FDK'      : intializes image to FDK reconstrucition
+%                  'FDK'      : Initializes image to FDK reconstruction
 %                  'multigrid': Initializes image by solving the problem in
 %                               small scale and increasing it when relative
 %                               convergence is reached.
 %                  'image'    : Initialization using a user specified
-%                               image. Not recomended unless you really
+%                               image. Not recommended unless you really
 %                               know what you are doing.
-%   'InitImg'      an image for the 'image' initialization. Aviod.
+%   'InitImg'      an image for the 'image' initialization. Avoid.
 %
 %   'Verbose'      1 or 0. Default is 1. Gives information about the
 %                  progress of the algorithm.
@@ -37,8 +36,8 @@ function [res,errorL2,qualMeasOut]=OS_SART(proj,geo,angles,niter,varargin)
 %                  quality measurement names. Example: {'CC','RMSE','MSSIM'}
 %                  These will be computed in each iteration.
 % 'OrderStrategy'  Chooses the subset ordering strategy. Options are
-%                  'ordered' :uses them in the input order, but divided
-%                  'random'  : orders them randomply
+%                  'ordered' : uses them in the input order, but divided
+%                  'random'  : orders them randomly
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
 % 'redundancy_weighting': true or false. Default is true. Applies data
@@ -91,19 +90,19 @@ end
 [alphablocks,orig_index]=order_subsets(angles,blocksize,OrderStrategy);
 
 
-% Projection weigth, W
+% Projection weight, W
 geoaux=geo;
-geoaux.sVoxel([1 2])=geo.sVoxel([1 2])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
+geoaux.sVoxel([1 2])=geo.sVoxel([1 2])*1.1; % a bit bigger, to avoid numerical division by zero (small number)
 geoaux.sVoxel(3)=max(geo.sDetector(2),geo.sVoxel(3)); % make sure lines are not cropped. One is for when image is bigger than detector and viceversa
 geoaux.nVoxel=[2,2,2]'; % accurate enough?
 geoaux.dVoxel=geoaux.sVoxel./geoaux.nVoxel;
-W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);  %
+W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);
 W(W<min(geo.dVoxel)/2)=Inf;
 W=1./W;
 
 % disp('Offset parameter size');
 % disp(size(geo.offDetector));
-% Back-Projection weigth, V
+% Back-Projection weight, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
 if redundancy_weights
@@ -118,7 +117,7 @@ if redundancy_weights
     W = W.*W_r; % include redundancy weighting in W
 end
 
-clear A x y dx dz;
+clear A x y dx dz
 
 
 %% hyperparameter stuff
@@ -186,7 +185,7 @@ for ii=1:niter
             res=res+lambda* bsxfun(@times,1./sum(V(:,:,jj),3),Atb(W(:,:,orig_index{jj}).*(proj(:,:,orig_index{jj})-Ax(res,geo,alphablocks{:,jj},'gpuids',gpuids)),geo,alphablocks{:,jj},'gpuids',gpuids));
         end
         
-        % Non-negativity constrain
+        % Non-negativity constraint
         if nonneg
             res=max(res,0);
         end
@@ -196,9 +195,9 @@ for ii=1:niter
     % If quality is being measured
     if measurequality
         
-        %Can save quality measure for every iteration here
-        %See if some image quality measure should be used for every
-        %iteration?
+        % Can save quality measure for every iteration here
+        % See if some image quality measure should be used for every
+        % iteration?
         qualMeasOut(:,ii)=Measure_Quality(res_prev,res,QualMeasOpts);
     end
     
@@ -218,22 +217,22 @@ for ii=1:niter
         geo.DSD=DSD;
         geo.rotDetector=rotDetector;
         errornow=im3Dnorm(proj-Ax(res,geo,angles,'Siddon','gpuids',gpuids),'L2');
-        %     If the error is not minimized
+        % If the error is not minimized
         if ii~=1 && errornow>errorL2(end) % This 1.1 is for multigrid, we need to focus to only that case
             if verbose
                 disp(['Convergence criteria met, exiting on iteration number:', num2str(ii)]);
             end
-            return;
+            return
         end
-        %     Store Error
+        % Store Error
         errorL2=[errorL2 errornow];
     end
-    % If timing was asked
+    % If timing was asked for
     if ii==1 && verbose==1
         expected_time=toc*(niter-1);
         expected_duration=toc*(niter);
         disp('OS_SART');
-        disp(['Expected duration  :    ',secs2hms(expected_duration)]);
+        disp(['Expected duration   :    ',secs2hms(expected_duration)]);
         disp(['Expected finish time:    ',datestr(datetime('now')+seconds(expected_time))]);
         disp('');
     end
@@ -251,7 +250,7 @@ geo.nVoxel=[64;64;64];
 geo.dVoxel=geo.sVoxel./geo.nVoxel;
 if any(finalsize<geo.nVoxel)
     initres=zeros(finalsize');
-    return;
+    return
 end
 niter=100;
 nblock=20;
@@ -279,7 +278,7 @@ end
 
 %% Parse inputs
 function [block_size,lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'blocksize','lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids','redundancy_weighting'};
+opts={'blocksize','lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -300,7 +299,7 @@ end
 for ii=1:length(opts)
     opt=opts{ii};
     default=defaults(ii);
-    % if one option isnot default, then extranc value from input
+    % if one option is not default, then extract value from input
     if default==0
         ind=double.empty(0,1);jj=1;
         while isempty(ind)
@@ -330,7 +329,7 @@ for ii=1:length(opts)
             if default
                 lambda=1;
             elseif ischar(val)&&strcmpi(val,'nesterov')
-                lambda='nesterov'; %just for lowercase/upercase
+                lambda='nesterov'; % just for lowercase/uppercase
             elseif length(val)>1 || ~isnumeric( val)
                 error('TIGRE:OS_SART:InvalidInput','Invalid lambda')
             else
@@ -359,19 +358,19 @@ for ii=1:length(opts)
             res=[];
             if default || strcmp(val,'none')
                 res=zeros(geo.nVoxel','single');
-                continue;
+                continue
             end
             if strcmp(val,'FDK')
                 res=FDK(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'multigrid')
                 res=init_multigrid(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'image')
                 initwithimage=1;
-                continue;
+                continue
             end
             if isempty(res)
                 error('TIGRE:OS_SART:InvalidInput','Invalid Init option')
@@ -379,7 +378,7 @@ for ii=1:length(opts)
             % % % % % % % ERROR
         case 'initimg'
             if default
-                continue;
+                continue
             end
             if exist('initwithimage','var')
                 if isequal(size(val),geo.nVoxel')
@@ -428,7 +427,3 @@ for ii=1:length(opts)
 end
 
 end
-
-
-
-

--- a/MATLAB/Algorithms/SART.m
+++ b/MATLAB/Algorithms/SART.m
@@ -1,10 +1,10 @@
 function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
-%SART solves Cone Beam CT image reconstruction using Oriented Subsets
-%              Simultaneous Algebraic Reconxtruction Techique algorithm
+% SART solves Cone Beam CT image reconstruction using Oriented Subsets
+%              Simultaneous Algebraic Reconstruction Technique algorithm
 %
 %   SART(PROJ,GEO,ALPHA,NITER) solves the reconstruction problem
 %   using the projection data PROJ taken over ALPHA angles, corresponding
-%   to the geometry descrived in GEO, using NITER iterations.
+%   to the geometry described in GEO, using NITER iterations.
 %
 %   SART(PROJ,GEO,ALPHA,NITER,OPT,VAL,...) uses options and values for solving. The
 %   possible options in OPT are:
@@ -12,17 +12,17 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 %
 %   'lambda':      Sets the value of the hyperparameter. Default is 1
 %
-%   'lambda_red':   Reduction of lambda.Every iteration
+%   'lambda_red':  Reduction of lambda. Every iteration
 %                  lambda=lambdared*lambda. Default is 0.99
 %
-%   'Init':        Describes diferent initialization techniques.
+%   'Init':        Describes different initialization techniques.
 %                  'none'     : Initializes the image to zeros (default)
-%                  'FDK'      : intializes image to FDK reconstrucition
+%                  'FDK'      : Initializes image to FDK reconstruction
 %                  'multigrid': Initializes image by solving the problem in
 %                               small scale and increasing it when relative
 %                               convergence is reached.
 %                  'image'    : Initialization using a user specified
-%                               image. Not recomended unless you really
+%                               image. Not recommended unless you really
 %                               know what you are doing.
 %   'InitImg'      an image for the 'image' initialization. Avoid.
 %
@@ -33,8 +33,8 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 %                  quality measurement names. Example: {'CC','RMSE','MSSIM'}
 %                  These will be computed in each iteration.
 % 'OrderStrategy'  Chooses the subset ordering strategy. Options are
-%                  'ordered' :uses them in the input order, but divided
-%                  'random'  : orders them randomply
+%                  'ordered' : uses them in the input order, but divided
+%                  'random'  : orders them randomly
 %                  'angularDistance': chooses the next subset with the
 %                                     biggest angular distance with the ones used.
 % 'redundancy_weighting': true or false. Default is true. Applies data
@@ -77,21 +77,21 @@ angles_reorder=cell2mat(alphablocks);
 if ~isfield(geo,'rotDetector')
     geo.rotDetector=[0;0;0];
 end
-%% Create weigthing matrices
+%% Create weighting matrices
 
-% Projection weigth, W
+% Projection weight, W
 
 geoaux=geo;
-geoaux.sVoxel([1 2])=geo.sDetector([1])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
+geoaux.sVoxel([1 2])=geo.sDetector(1)*1.1; % a bit bigger, to avoid numerical division by zero (small number)
 geoaux.sVoxel(3)=max(geo.sDetector(2),geo.sVoxel(3)); % make sure lines are not cropped. One is for when image is bigger than detector and viceversa
 geoaux.nVoxel=[2,2,2]'; % accurate enough?
 geoaux.dVoxel=geoaux.sVoxel./geoaux.nVoxel;
-W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);  %
+W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);
 W(W<min(geo.dVoxel)/4)=Inf;
 W=1./W;
 W(W>0.1)=0.1;
 
-% Back-Projection weigth, V
+% Back-Projection weight, V
 V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 
 if redundancy_weights
@@ -189,13 +189,13 @@ for ii=1:niter
         geo.offDetector=offDetector;
         geo.DSD=DSD;
         geo.rotDetector=rotDetector;
-        errornow=im3Dnorm(proj-Ax(res,geo,angles,'gpuids',gpuids),'L2');                       % Compute error norm2 of b-Ax
-        %         If the error is not minimized.
+        errornow=im3Dnorm(proj-Ax(res,geo,angles,'gpuids',gpuids),'L2'); % Compute error norm2 of b-Ax
+        % If the error is not minimized.
         if  ii~=1 && errornow>errorL2(end)
             if verbose
                 disp(['Convergence criteria met, exiting on iteration number:', num2str(ii)]);
             end
-            return;
+            return
         end
         errorL2=[errorL2 errornow];
     end
@@ -249,7 +249,7 @@ end
 
 
 function [lambda,res,lambdared,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids','redundancy_weighting'};
+opts={'lambda','init','initimg','verbose','lambda_red','qualmeas','orderstrategy','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -270,7 +270,7 @@ end
 for ii=1:length(opts)
     opt=opts{ii};
     default=defaults(ii);
-    % if one option isnot default, then extranc value from input
+    % if one option is not default, then extract value from input
     if default==0
         ind=double.empty(0,1);jj=1;
         while isempty(ind)
@@ -300,8 +300,8 @@ for ii=1:length(opts)
             if default
                 lambda=1;
             elseif ischar(val)&&strcmpi(val,'nesterov')
-                lambda='nesterov'; %just for lowercase/upercase
-            elseif length(val)>1 || ~isnumeric( val)
+                lambda='nesterov'; % just for lowercase/uppercase
+            elseif length(val)>1 || ~isnumeric(val)
                 error('TIGRE:SART:InvalidInput','Invalid lambda')
             else
                 lambda=val;
@@ -310,7 +310,7 @@ for ii=1:length(opts)
             if default
                 lambdared=1;
             else
-                if length(val)>1 || ~isnumeric( val)
+                if length(val)>1 || ~isnumeric(val)
                     error('TIGRE:SART:InvalidInput','Invalid lambda')
                 end
                 lambdared=val;
@@ -319,19 +319,19 @@ for ii=1:length(opts)
             res=[];
             if default || strcmp(val,'none')
                 res=zeros(geo.nVoxel','single');
-                continue;
+                continue
             end
             if strcmp(val,'FDK')
                 res=FDK(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'multigrid')
                 res=init_multigrid(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'image')
-                initwithimage=1;     % it is used (10 lines below)
-                continue;
+                initwithimage=1; % it is used (10 lines below)
+                continue
             end
             if isempty(res)
                 error('TIGRE:SART:InvalidInput','Invalid Init option')
@@ -339,7 +339,7 @@ for ii=1:length(opts)
             % % % % % % % ERROR
         case 'initimg'
             if default
-                continue;
+                continue
             end
             if exist('initwithimage','var')
                 if isequal(size(val),geo.nVoxel')

--- a/MATLAB/Algorithms/SIRT.m
+++ b/MATLAB/Algorithms/SIRT.m
@@ -1,10 +1,10 @@
 function [res,errorL2,qualMeasOut]=SIRT(proj,geo,angles,niter,varargin)
 % SIRT solves Cone Beam CT image reconstruction using Oriented Subsets
-%              Simultaneous Algebraic Reconxtruction Techique algorithm
+%              Simultaneous Algebraic Reconstruction Technique algorithm
 %
 %   SIRT(PROJ,GEO,ALPHA,NITER) solves the reconstruction problem
 %   using the projection data PROJ taken over ALPHA angles, corresponding
-%   to the geometry descrived in GEO, using NITER iterations.
+%   to the geometry described in GEO, using NITER iterations.
 %
 %   SIRT(PROJ,GEO,ALPHA,NITER,OPT,VAL,...) uses options and values for solving. The
 %   possible options in OPT are:
@@ -12,17 +12,17 @@ function [res,errorL2,qualMeasOut]=SIRT(proj,geo,angles,niter,varargin)
 %
 %   'lambda':      Sets the value of the hyperparameter. Default is 1
 %
-%   'lambda_red':   Reduction of lambda.Every iteration
+%   'lambda_red':  Reduction of lambda. Every iteration
 %                  lambda=lambdared*lambda. Default is 0.95
 %
-%   'Init':        Describes diferent initialization techniques.
+%   'Init':        Describes different initialization techniques.
 %                  'none'     : Initializes the image to zeros (default)
-%                  'FDK'      : intializes image to FDK reconstrucition
+%                  'FDK'      : Initializes image to FDK reconstruction
 %                  'multigrid': Initializes image by solving the problem in
 %                               small scale and increasing it when relative
 %                               convergence is reached.
 %                  'image'    : Initialization using a user specified
-%                               image. Not recomended unless you really
+%                               image. Not recommended unless you really
 %                               know what you are doing.
 %   'InitImg'      an image for the 'image' initialization. Avoid.
 %
@@ -63,28 +63,25 @@ if nargout>1
 else
     computeL2=false;
 end
-errorL2=[];
 
-%% initialize stuff
+%% Create weighting matrices
 
-%% Create weigthing matrices
-
-% Projection weigth, W
+% Projection weight, W
 
 geoaux=geo;
-geoaux.sVoxel([1 2])=geo.sVoxel([1 2])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
+geoaux.sVoxel([1 2])=geo.sVoxel([1 2])*1.1; % a bit bigger, to avoid numerical division by zero (small number)
 geoaux.sVoxel(3)=max(geo.sDetector(2),geo.sVoxel(3)); % make sure lines are not cropped. One is for when image is bigger than detector and viceversa
 geoaux.nVoxel=[2,2,2]'; % accurate enough?
 geoaux.dVoxel=geoaux.sVoxel./geoaux.nVoxel;
-W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);  %
+W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);
 W(W<min(geo.dVoxel)/4)=Inf;
 W=1./W;
 
 % disp('Size of W matrix');
 % disp(size(W));
-clear geoaux;
+clear geoaux
 
-% Back-Projection weigth, V
+% Back-Projection weight, V
 V=computeV(geo,angles,{angles},{1:length(angles)},'gpuids',gpuids);
 
 if redundancy_weights
@@ -156,19 +153,19 @@ for ii=1:niter
     end
     
     if computeL2 || nesterov
-        errornow=im3Dnorm(proj-Ax(res,geo,angles,'gpuids',gpuids),'L2','gpuids',gpuids);                       % Compute error norm2 of b-Ax
+        errornow=im3Dnorm(proj-Ax(res,geo,angles,'gpuids',gpuids),'L2','gpuids',gpuids); % Compute error norm2 of b-Ax
         % If the error is not minimized.
         if  ii~=1 && errornow>errorL2(end)
             if verbose
                 disp(['Convergence criteria met, exiting on iteration number:', num2str(ii)]);
             end
-            return;
+            return
         end
         errorL2=[errorL2 errornow];
     end
     
     
-    if (ii==1 && verbose==1);
+    if (ii==1 && verbose==1)
         expected_time=toc*niter;
         disp('SIRT');
         disp(['Expected duration   :    ',secs2hms(expected_time)]);
@@ -192,7 +189,7 @@ geo.nVoxel=[64;64;64];
 geo.dVoxel=geo.sVoxel./geo.nVoxel;
 if any(finalsize<geo.nVoxel)
     initres=zeros(finalsize');
-    return;
+    return
 end
 niter=100;
 initres=zeros(geo.nVoxel');
@@ -220,7 +217,7 @@ end
 
 
 function [lambda,res,lambdared,verbose,QualMeasOpts,nonneg,gpuids,redundancy_weights]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'lambda','init','initimg','verbose','lambda_red','qualmeas','nonneg','gpuids','redundancy_weighting'};
+opts={'lambda','init','initimg','verbose','lambda_red','qualmeas','nonneg','gpuids','redundancy_weighting'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -241,7 +238,7 @@ end
 for ii=1:length(opts)
     opt=opts{ii};
     default=defaults(ii);
-    % if one option isnot default, then extranc value from input
+    % if one option is not default, then extract value from input
     if default==0
         ind=double.empty(0,1);jj=1;
         while isempty(ind)
@@ -270,9 +267,9 @@ for ii=1:length(opts)
         case 'lambda'
             if default
                 lambda=1;
-            elseif ischar(val)&&strcmpi(val,'nesterov');
-                lambda='nesterov'; %just for lowercase/upercase
-            elseif length(val)>1 || ~isnumeric( val)
+            elseif ischar(val)&&strcmpi(val,'nesterov')
+                lambda='nesterov'; % just for lowercase/uppercase
+            elseif length(val)>1 || ~isnumeric(val)
                 error('TIGRE:SIRT:InvalidInput','Invalid lambda')
             else
                 lambda=val;
@@ -281,7 +278,7 @@ for ii=1:length(opts)
             if default
                 lambdared=1;
             else
-                if length(val)>1 || ~isnumeric( val)
+                if length(val)>1 || ~isnumeric(val)
                     error('TIGRE:SIRT:InvalidInput','Invalid lambda')
                 end
                 lambdared=val;
@@ -290,19 +287,19 @@ for ii=1:length(opts)
             res=[];
             if default || strcmp(val,'none')
                 res=zeros(geo.nVoxel','single');
-                continue;
+                continue
             end
             if strcmp(val,'FDK')
                 res=FDK(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'multigrid')
                 res=init_multigrid(proj,geo,alpha);
-                continue;
+                continue
             end
             if strcmp(val,'image')
                 initwithimage=1;
-                continue;
+                continue
             end
             if isempty(res)
                 error('TIGRE:SIRT:InvalidInput','Invalid Init option')
@@ -310,10 +307,10 @@ for ii=1:length(opts)
             % % % % % % % ERROR
         case 'initimg'
             if default
-                continue;
+                continue
             end
-            if exist('initwithimage','var');
-                if isequal(size(val),geo.nVoxel');
+            if exist('initwithimage','var')
+                if isequal(size(val),geo.nVoxel')
                     res=single(val);
                 else
                     error('TIGRE:SIRT:InvalidInput','Invalid image for initialization');


### PR DESCRIPTION
In SART_TV.m, the voxel size used when calculating the W weights is `geo.DSD-geo.DSO`. This errors when the length of `DSD` or `DSO` is greater than 2, i.e. for varying `DSD` and `DSO` (e.g. tomosynthesis scans). This PR changes it to match the voxel size used in SART.m. The rest of the changes are typos/cleaning up a bit.

I will not change the voxel sizes used in SIRT or OS-SART yet, as alignment will come when https://github.com/CERN/TIGRE/issues/402 is implemented. This is purely to fix a bug in the short term. 