### PR TITLE
Use original geometry for FDK redundancy weighting

### DIFF
--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -46,12 +46,10 @@ geo.filter=filter;
 if dowang
     % Zero-padding to avoid FFT-induced aliasing %TODO: should't this be
     % for all cases, not just wang?
-    [zproj, zgeo] = zeropadding(proj, geo);
     % Preweighting using Wang function
-    proj=zproj.*redundancy_weighting(zgeo, geo);
-    % Replace original proj and geo
-    % proj = proj_w;
-    geo = zgeo;
+    proj=proj.*redundancy_weighting(geo);
+    [proj, geo] = zeropadding(proj, geo);
+
 end
 
 if size(geo.offDetector,2)==1

--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -48,7 +48,7 @@ if dowang
     % for all cases, not just wang?
     [zproj, zgeo] = zeropadding(proj, geo);
     % Preweighting using Wang function
-    proj=zproj.*redundancy_weighting(zgeo);
+    proj=zproj.*redundancy_weighting(zgeo, geo);
     % Replace original proj and geo
     % proj = proj_w;
     geo = zgeo;

--- a/MATLAB/Utilities/Atb.m
+++ b/MATLAB/Utilities/Atb.m
@@ -54,7 +54,7 @@ if size(angles,1)==1
 end
 %% geometry
 geo=checkGeo(geo,angles);
-assert(isequal([size(projections,2) size(projections,1)],geo.nDetector.'),'TIGRE:checkGeo:BadGeometry','nVoxel does not match with provided image size');
+assert(isequal([size(projections,2) size(projections,1)],geo.nDetector.'),'TIGRE:checkGeo:BadGeometry','nDetector does not match with provided image size');
 
 %% Thats it, lets call the mex fucntion
 

--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -12,8 +12,8 @@ offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
 us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
 
 us = us * geo.DSO(1)/geo.DSD(1);
-theta = (end.sDetector(1)/2 - abs(end.offDetector(1)))...
-        * sign(end.offDetector(1));
+theta = (geo.sDetector(1)/2 - abs(geo.offDetector(1)))...
+        * sign(geo.offDetector(1));
 abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
 
 w = ones([geo.nDetector(2),geo.nDetector(1)]);

--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -1,4 +1,4 @@
-function w = redundancy_weighting(geo)
+function w = redundancy_weighting(geo, originalGeo)
 % Preweighting using Wang function
 % Ref: 
 %    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
@@ -6,17 +6,20 @@ function w = redundancy_weighting(geo)
 if ~isfield(geo,'COR')
     geo.COR=0;
 end
+if nargin == 1
+    originalGeo = geo;
+end
 offset = geo.offDetector(1);
 offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
 us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
 
 us = us * geo.DSO(1)/geo.DSD(1);
-theta = (geo.sDetector(1)/2 - abs(offset))...
-        * sign(offset);
+theta = (originalGeo.sDetector(1)/2 - abs(originalGeo.offDetector(1)))...
+        * sign(originalGeo.offDetector(1));
 abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
 
 w = ones([geo.nDetector(2),geo.nDetector(1)]);
-if apply_wang_weights(geo)
+if apply_wang_weights(originalGeo)
     for ii = 1:geo.nDetector
         t = us(ii);
         if(abs(t) <= abstheta)

--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -1,4 +1,4 @@
-function w = redundancy_weighting(geo, originalGeo)
+function w = redundancy_weighting(geo)
 % Preweighting using Wang function
 % Ref: 
 %    Wang, Ge. X-ray micro-CT with a displaced detector array. Medical Physics, 2002,29(7):1634-1636.
@@ -6,20 +6,18 @@ function w = redundancy_weighting(geo, originalGeo)
 if ~isfield(geo,'COR')
     geo.COR=0;
 end
-if nargin == 1
-    originalGeo = geo;
-end
+
 offset = geo.offDetector(1);
 offset = offset + (geo.DSD(1) / geo.DSO(1)) * geo.COR(1);   % added correction
 us = ((-geo.nDetector(1)/2+0.5):1:(geo.nDetector(1)/2-0.5))*geo.dDetector(1) + abs(offset);
 
 us = us * geo.DSO(1)/geo.DSD(1);
-theta = (originalGeo.sDetector(1)/2 - abs(originalGeo.offDetector(1)))...
-        * sign(originalGeo.offDetector(1));
+theta = (end.sDetector(1)/2 - abs(end.offDetector(1)))...
+        * sign(end.offDetector(1));
 abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
 
 w = ones([geo.nDetector(2),geo.nDetector(1)]);
-if apply_wang_weights(originalGeo)
+if apply_wang_weights(geo)
     for ii = 1:geo.nDetector
         t = us(ii);
         if(abs(t) <= abstheta)


### PR DESCRIPTION
Following https://github.com/CERN/TIGRE/pull/415 I noticed another bug in FDK offset weighting. It may have been introduced by me in https://github.com/CERN/TIGRE/pull/415, or in the original PR https://github.com/CERN/TIGRE/pull/376.

The `redundancy_weighting` function was using the new `zgeo` structure that comes out of `zeropadding`, which means the detector offset is zero (so the weighting is turned off automatically) and `theta` was being calculated incorrectly anyway. I fixed this by passing in the original `geo` structure as an additional input for FDK only; for all other algorithms there is no zero-padding as far as I'm aware, so the correct `geo` structure is used.

Also fixed a weight bug in MLEM.