### PR TITLE
Updates to Nikon loader

### DIFF
--- a/Python/tigre/utilities/io/NikonDataLoader.py
+++ b/Python/tigre/utilities/io/NikonDataLoader.py
@@ -39,8 +39,9 @@ def NikonDataLoader(filepath, **kwargs):
 
 def readXtekctGeometry(filepath):
 
-    # Developed by A. Biguri and W. Sun
+    # Developed by A. Biguri, W. Sun, P Basford
     # W. Sun edited on 06.10.2018 for 3D pro version 5.2.6809.15380 (2018)
+    # P. Basford edited May 2022 for Inspect-X version 6.8 compatibility
 
     if filepath.endswith(".xtekct"):
         folder, ini = os.path.split(filepath)
@@ -90,7 +91,10 @@ def readXtekctGeometry(filepath):
     #%% Global geometry
     geometry.DSO = float(cfg["SrcToObject"])
     geometry.DSD = float(cfg["SrcToDetector"])
-    geometry.COR = -float(cfg["CentreOfRotationTop"])
+    try:
+        geometry.COR = -float(cfg["CentreOfRotationTop"])
+    except KeyError:
+        geometry.COR = -float(cfg["ObjectOffsetX"])
 
     if geometry.COR == 0:
         print(

--- a/Python/tigre/utilities/io/NikonDataLoader.py
+++ b/Python/tigre/utilities/io/NikonDataLoader.py
@@ -36,7 +36,6 @@ def NikonDataLoader(filepath, **kwargs):
     folder, geometry, angles = readXtekctGeometry(filepath)
     return loadNikonProjections(folder, geometry, angles, **kwargs)
 
-
 def readXtekctGeometry(filepath):
 
     # Developed by A. Biguri, W. Sun, P Basford
@@ -130,14 +129,14 @@ def readXtekctGeometry(filepath):
             for i in range(3):
                 file.readline()
             for line in file:
-                angles.append(math.radians(float(line.split("\t")[1])))
+                angles.append(-math.radians(float(line.split("\t")[1])))
         return folder, geometry, numpy.array(angles)
 
     print("File with definition of angles not found, estimating them from geometry info.")
     n_angles = int(cfg["Projections"])
     angle_step = float(cfg["AngularStep"])
     initial_angle = float(cfg["InitialAngle"])
-    angles = numpy.arange(n_angles) * math.radians(angle_step) + math.radians(initial_angle)
+    angles = -(numpy.arange(n_angles) * math.radians(angle_step) + math.radians(initial_angle))
 
     return folder, geometry, angles
 


### PR DESCRIPTION
Using the in built Nikon loader with a scan from Inspect-X 6.8 highlighted the fact that it now stores the calculated CoR in a different field in the .xtekct file, and the reconstructions generated were invalid.  Both issues are fixed in this PR.  The invalid reconstruction issue was due to difference in expected rotation direction.