### PR TITLE
Fixed np.int in iterative_recon_alg.py

### DIFF
--- a/Python/tigre/algorithms/iterative_recon_alg.py
+++ b/Python/tigre/algorithms/iterative_recon_alg.py
@@ -380,7 +380,7 @@ class IterativeReconAlg(object):
         :return: None
         """
 
-        ang_index = self.angle_index[iteration].astype(np.int)
+        ang_index = self.angle_index[iteration].astype(np.int32)
 
         self.res += (
             self.lmbda


### PR DESCRIPTION
Minor fix to prevent deprecation-related errors from numpy (#430):

Using the Python installation of TIGRE raised the error:  `AttributeError: module numpy has no attribute int. np.int was a deprecated alias for the builtin int.` This happens while running demos and functions utilizing iterative_recon_alg. Changing `np.int` to `np.int32` fixes the issues, as proposed by the complete numpy error message:
```
AttributeError: module numpy has no attribute int.
np.int was a deprecated alias for the builtin int. To avoid this error in existing code, use int by itself. Doing this will not modify any behavior and is safe. When replacing np.int, you may wish to use e.g. np.int64 or np.int32 to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.
```

This was the only remaining instance of `np.int` I could find. 