### PR TITLE
Fix Parker weights on python code

### DIFF
--- a/Python/tigre/algorithms/single_pass_algorithms.py
+++ b/Python/tigre/algorithms/single_pass_algorithms.py
@@ -73,6 +73,7 @@ def FDK(proj, geo, angles, **kwargs):
     verbose = kwargs["verbose"] if "verbose" in kwargs else False
 
     gpuids = kwargs["gpuids"] if "gpuids" in kwargs else None
+    parker = kwargs["parker"] if "parker" in kwargs else False
     geo = copy.deepcopy(geo)
     geo.check_geo(angles)
     geo.checknans()
@@ -88,7 +89,7 @@ def FDK(proj, geo, angles, **kwargs):
     w = geo.DSD[0] / np.sqrt((geo.DSD[0] ** 2 + xx ** 2 + yy ** 2))
     np.multiply(proj, w, out=proj_filt)
 
-    proj_filt = filtering(proj_filt, geo, angles, parker=False, verbose=verbose)
+    proj_filt = filtering(proj_filt, geo, angles, parker=parker, verbose=verbose)
     
     return Atb(proj_filt, geo, geo.angles, "FDK", gpuids=gpuids)
 

--- a/Python/tigre/utilities/parkerweight.py
+++ b/Python/tigre/utilities/parkerweight.py
@@ -5,18 +5,31 @@ import warnings
 
 import numpy as np
 
+# Wesarg, Stefan, Matthias Ebert, and Thomas Bortfeld. 
+# "Parker weights revisited." Medical physics 29.3 (2002): 372-378.
+
+# @article{wesarg2002parker,
+#   title={Parker weights revisited},
+#   author={Wesarg, Stefan and Ebert, Matthias and Bortfeld, Thomas},
+#   journal={Medical physics},
+#   volume={29},
+#   number={3},
+#   pages={372--378},
+#   year={2002},
+#   publisher={American Association of Physicists in Medicine}
+# }
+
 
 def parkerweight(proj, geo, angles, q):
     start = -geo.sDetector[0] / 2 + geo.dDetector[0] / 2
     stop = geo.sDetector[0] / 2 - geo.dDetector[0] / 2
     step = geo.dDetector[0]
-    alpha = np.arctan(np.arange(start, stop + step, step) / geo.DSD)
+    alpha = np.arctan(np.arange(start, stop + step, step) / np.mean(geo.DSD))
     alpha = -alpha
     delta = abs(alpha[0] - alpha[-1]) / 2
-    totangles = np.cumsum(np.diff(angles))
-    totangles = totangles[-1]
+    totangles = abs(angles[0] - angles[-1]) 
 
-    if totangles < 2 * np.pi:
+    if totangles > 2 * np.pi:
         warnings.warn(
             "Computing Parker weigths for scanning angle equal or bigger than 2*pi "
             "Consider disabling Parker weigths."
@@ -28,9 +41,10 @@ def parkerweight(proj, geo, angles, q):
         )
     epsilon = max(totangles - (np.pi + 2 * delta), 0)
 
-    # for i in range(proj.shape[0]):
-    for i in range(33):
-        beta = angles[i]
+    for ii in range(proj.shape[0]):
+        
+        beta = abs(angles[ii]-angles[0])
+        
         w = 0.5 * (
             s_function(beta / b_subf(alpha, delta, epsilon, q) - 0.5)
             + s_function(
@@ -41,7 +55,7 @@ def parkerweight(proj, geo, angles, q):
                 (beta - np.pi - 2 * delta - epsilon) / b_subf(-alpha, delta, epsilon, q) + 0.5
             )  # noqa: E501
         )
-        proj[i] *= w
+        proj[ii] *= np.tile(w, [proj.shape[-1], 1])
 
     return proj
 


### PR DESCRIPTION
Minor fixes to make Parker weights work on Python code. Simple experiments using a 3D SheppLogan phantom suggest it is working. 

