### PR TITLE
Twin Robotic Computed Tomography Geometries / ASTRA

### DIFF
--- a/Python/tigre/utilities/common_geometry.py
+++ b/Python/tigre/utilities/common_geometry.py
@@ -158,6 +158,9 @@ def ArbitrarySourceDetectorFixedObject(
             focal_spot_position_mm, detector_center_position_mm)
         focal_spot_position_mm = focal_spot_position_mm - trajectory_center_mm
         detector_center_position_mm = detector_center_position_mm - trajectory_center_mm
+    else:
+        trajectory_center_mm = np.zeros((3,))
+        
     
     geometry = Geometry()
     geometry.mode = 'cone'

--- a/Python/tigre/utilities/common_geometry.py
+++ b/Python/tigre/utilities/common_geometry.py
@@ -138,20 +138,31 @@ def ArbitrarySourceDetMoveGeo(geo,s_pos,d_pos=None,d_rot=None) -> Geometry:
 
 
 def ArbitrarySourceDetectorFixedObject(
+        geometry: Geometry,
         focal_spot_position_mm: np.ndarray, 
         detector_center_position_mm: np.ndarray, 
         detector_line_direction: np.ndarray, 
         detector_column_direction: np.ndarray,
+        origin_mm: np.ndarray | None = None,
         use_center_correction: bool = True) -> Geometry:
     """
-    geo: Geometry, that gets appended
-    ...
-    detector_rotation_marix: x_axis: (0, 0) -> (0, 1);  y_ais (0, 0) -> (1, 0)
+    geo: Geometry object
+    focal_spot_position_mm: position of the source, 
+    detector_center_position_mm: position of the detector center, 
+    detector_line_direction: detecor line vector from pixel (0, 0) -> (0, 1), 
+    detector_column_direction: detecor column vector from pixel (0, 0) -> (1, 0),
+    origin_mm: origin of the ct trajectory. The source and detector positions are translated with this value. Defaults to: None.
+    use_center_correction: Calculate an arbiatary origin of the trajectory. Defaults to: True.
     """
 
     # Assumption: CT trajectory has one rotation center.
     number_of_projection = focal_spot_position_mm.shape[0]
     
+    if origin_mm is None:
+        origin_mm = np.zeros((3,))
+
+    focal_spot_position_mm = focal_spot_position_mm - origin_mm
+    detector_center_position_mm = detector_center_position_mm - origin_mm
     
     if use_center_correction:
         trajectory_center_mm = calculate_trajectory_center_mm(
@@ -160,10 +171,6 @@ def ArbitrarySourceDetectorFixedObject(
         detector_center_position_mm = detector_center_position_mm - trajectory_center_mm
     else:
         trajectory_center_mm = np.zeros((3,))
-        
-    
-    geometry = Geometry()
-    geometry.mode = 'cone'
 
     if not use_center_correction:
         geometry.offOrigin = trajectory_center_mm.reshape((3, ))

--- a/Python/tigre/utilities/common_geometry.py
+++ b/Python/tigre/utilities/common_geometry.py
@@ -174,7 +174,6 @@ def ArbitrarySourceDetectorFixedObject(
 
     if not use_center_correction:
         geometry.offOrigin = trajectory_center_mm.reshape((3, ))
-    trajectory_center_mm += 0.
 
     # source and detector are orthogonal. The angle is rotates the source from the x axis.
 

--- a/Python/tigre/utilities/common_geometry.py
+++ b/Python/tigre/utilities/common_geometry.py
@@ -154,6 +154,8 @@ def ArbitrarySourceDetectorFixedObject(
     
     
     if use_center_correction:
+        trajectory_center_mm = calculate_trajectory_center_mm(
+            focal_spot_position_mm, detector_center_position_mm)
         focal_spot_position_mm = focal_spot_position_mm - trajectory_center_mm
         detector_center_position_mm = detector_center_position_mm - trajectory_center_mm
     


### PR DESCRIPTION
Hello TIGRE team! 
I am a PhD student at the Deggendorf Institute of Technology where we are working with a twin robotic computed tomography scanner. I usually use the astra toolbox for reconstruction, but I wanted to try out the many algorithms implemented in the TIGRE toolbox and the cool features like the multi GPU! I found it rather unintuitive to convert the complex arbitrary geometry into TIGRE, so I've added a utility function. I tested the results and made a short colab example with the conversion from astra to TIGRE (I thought it might be interesting for others).

https://colab.research.google.com/drive/1c6tEySsv63zIdkHvo6agg3O2vJoKYTC1?usp=sharing

With our twin robot CT system we have correction values for each projection. I found the TIGRE interface rather unintuitive, especially compared to the Astra 'cone_vec' interface. I took a quick look at the TIGRE cuda files and found that in the forward and backprojector the interface is more or less the same as the Astra 'cone_vec' geometry. Is it worth looking into this and maybe making a more "arbitrary" python interface for TIGRE? I might look into it when I have some spare time.

Greetings Simon