### PR TITLE
Fix failing plots

### DIFF
--- a/Python/tigre/utilities/visualization/plot_geometry.py
+++ b/Python/tigre/utilities/visualization/plot_geometry.py
@@ -15,7 +15,7 @@ class Arrow3D(matplotlib.patches.FancyArrowPatch):
         from mpl_toolkits.mplot3d import proj3d
 
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         matplotlib.patches.FancyArrowPatch.draw(self, renderer)
 


### PR DESCRIPTION
Replace deprecated Pyplot "renderer.M" object. See https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html#d-properties-on-renderers

Fixes #511