### PR TITLE
float precision fix for issue #544

### DIFF
--- a/Common/CUDA/types_TIGRE.hpp
+++ b/Common/CUDA/types_TIGRE.hpp
@@ -89,4 +89,21 @@ struct  Geometry {
     float y;
     float z;
 };
+
+struct Point3Ddouble{
+    double x;
+    double y;
+    double z;
+
+    // cast to float member function for "copying" Point3Ddouble to Point3D
+    Point3D to_float()
+    {
+        Point3D castToFloat;
+        castToFloat.x = (float)x;
+        castToFloat.y = (float)y;
+        castToFloat.z = (float)z;
+        return(castToFloat);
+    }
+};
+
 #endif

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -752,6 +752,69 @@ void freeGeoArray(unsigned int splits,Geometry* geoArray){
     }
     free(geoArray);
 }
+
+
+//______________________________________________________________________________
+//
+//      double precision functions for rotating Point3Ddouble coordinates
+//______________________________________________________________________________
+
+void eulerZYZT_double(Geometry geo, Point3Ddouble* point){
+    
+    Point3Ddouble auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+
+    // calculate sin and cos of 3 angles (used multiple times)
+    double sin_alpha, cos_alpha, sin_theta, cos_theta, sin_psi, cos_psi;
+    sin_alpha = sin((double)geo.alpha);
+    cos_alpha = cos((double)geo.alpha);
+    sin_theta = sin((double)geo.theta);
+    cos_theta = cos((double)geo.theta);
+    sin_psi = sin((double)geo.psi);
+    cos_psi = cos((double)geo.psi);
+    
+    point->x = auxPoint.x*(cos_psi*cos_theta*cos_alpha-sin_psi*sin_alpha)
+    +auxPoint.y*(-cos_psi*cos_theta*sin_alpha-sin_psi*cos_alpha)
+    +auxPoint.z*cos_psi*sin_theta;
+    point->y = auxPoint.x*(sin_psi*cos_theta*cos_alpha+cos_psi*sin_alpha)
+    +auxPoint.y*(-sin_psi*cos_theta*sin_alpha+cos_psi*cos_alpha)
+    +auxPoint.z*sin_psi*sin_theta;
+    point->z =-auxPoint.x*sin_theta*cos_alpha
+    +auxPoint.y*sin_theta*sin_alpha
+    +auxPoint.z*cos_theta;
+}
+
+void rollPitchYawT_double(Geometry geo,int i, Point3Ddouble* point){
+
+    Point3Ddouble auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+
+    // calculate sin and cos of 3 angles (used multiple times)
+    double sin_dRoll, cos_dRoll, sin_dPitch, cos_dPitch, sin_dYaw, cos_dYaw;
+    sin_dRoll = sin((double)geo.dRoll[i]);
+    cos_dRoll = cos((double)geo.dRoll[i]);
+    sin_dPitch = sin((double)geo.dPitch[i]);
+    cos_dPitch = cos((double)geo.dPitch[i]);
+    sin_dYaw = sin((double)geo.dYaw[i]);
+    cos_dYaw = cos((double)geo.dYaw[i]);
+    
+    point->x=cos_dRoll*cos_dPitch*auxPoint.x
+            +sin_dRoll*cos_dPitch*auxPoint.y
+            -sin_dPitch*auxPoint.z;
+    
+    point->y=(cos_dRoll*sin_dPitch*sin_dYaw - sin_dRoll*cos_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*sin_dYaw + cos_dRoll*cos_dYaw)*auxPoint.y
+            +cos_dPitch*sin_dYaw*auxPoint.z;
+    
+    point->z=(cos_dRoll*sin_dPitch*cos_dYaw + sin_dRoll*sin_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*cos_dYaw - cos_dRoll*sin_dYaw)*auxPoint.y
+            +cos_dPitch*cos_dYaw*auxPoint.z;
+}
+
 //______________________________________________________________________________
 //
 //      Function:       computeDeltasCube
@@ -763,27 +826,24 @@ void freeGeoArray(unsigned int splits,Geometry* geoArray){
 void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S)
 {
     
-    Point3D P, Px,Py,Pz;
+    // initialize points with double precision
+    Point3Ddouble P, Px,Py,Pz;
+
     // Get coords of Img(0,0,0)
     P.x=-(geo.sVoxelX/2-geo.dVoxelX/2)+geo.offOrigX[i];
     P.y=-(geo.sVoxelY/2-geo.dVoxelY/2)+geo.offOrigY[i];
     P.z=-(geo.sVoxelZ/2-geo.dVoxelZ/2)+geo.offOrigZ[i];
     
-    // Get coors from next voxel in each direction
-    Px.x=P.x+geo.dVoxelX;      Py.x=P.x;                Pz.x=P.x;
+    // Get coords from next voxel in each direction
+    Px.x=P.x+geo.dVoxelX;       Py.x=P.x;                Pz.x=P.x;
     Px.y=P.y;                   Py.y=P.y+geo.dVoxelY;    Pz.y=P.y;
     Px.z=P.z;                   Py.z=P.z;                Pz.z=P.z+geo.dVoxelZ;
     
-    
-    
-// Rotate image around X axis (this is equivalent of rotating the source and detector) RZ RY RZ
-    
-    eulerZYZT(geo,&P);
-    eulerZYZT(geo,&Px);
-    eulerZYZT(geo,&Py);
-    eulerZYZT(geo,&Pz);
-    
-    
+    // Rotate image around X axis (this is equivalent of rotating the source and detector) RZ RY RZ
+    eulerZYZT_double(geo,&P);
+    eulerZYZT_double(geo,&Px);
+    eulerZYZT_double(geo,&Py);
+    eulerZYZT_double(geo,&Pz);
     
     //detector offset
     P.z =P.z-geo.offDetecV[i];            P.y =P.y-geo.offDetecU[i];
@@ -793,29 +853,27 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     
     //Detector Roll pitch Yaw
     //
-    //
     // first, we need to offset everything so (0,0,0) is the center of the detector
     // Only X is required for that
     P.x=P.x+(geo.DSD[i]-geo.DSO[i]);
     Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
     Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
     Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
-    rollPitchYawT(geo,i,&P);
-    rollPitchYawT(geo,i,&Px);
-    rollPitchYawT(geo,i,&Py);
-    rollPitchYawT(geo,i,&Pz);
+    rollPitchYawT_double(geo,i,&P);
+    rollPitchYawT_double(geo,i,&Px);
+    rollPitchYawT_double(geo,i,&Py);
+    rollPitchYawT_double(geo,i,&Pz);
     
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
     Py.x=Py.x-(geo.DSD[i]-geo.DSO[i]);
     Pz.x=Pz.x-(geo.DSD[i]-geo.DSO[i]);
     //Done for P, now source
-    Point3D source;
+    Point3Ddouble source;
     source.x=geo.DSD[i]; //already offseted for rotation
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
-    rollPitchYawT(geo,i,&source);
-    
+    rollPitchYawT_double(geo,i,&source);
     
     source.x=source.x-(geo.DSD[i]-geo.DSO[i]);//   source.y=source.y-auxOff.y;    source.z=source.z-auxOff.z;
     
@@ -834,9 +892,9 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     deltaY->x=Py.x-P.x;   deltaY->y=Py.y-P.y;    deltaY->z=Py.z-P.z;
     deltaZ->x=Pz.x-P.x;   deltaZ->y=Pz.y-P.y;    deltaZ->z=Pz.z-P.z;
     
-    
-    *xyzorigin=P;
-    *S=source;
+    // cast the results from the double precision calculations back to float
+    *xyzorigin=P.to_float();
+    *S=source.to_float();
 }
 
 void eulerZYZT(Geometry geo, Point3D* point){
@@ -845,36 +903,52 @@ void eulerZYZT(Geometry geo, Point3D* point){
     auxPoint.x=point->x;
     auxPoint.y=point->y;
     auxPoint.z=point->z;
+
+    float sin_alpha, cos_alpha, sin_theta, cos_theta, sin_psi, cos_psi;
+    sin_alpha = sin(geo.alpha);
+    cos_alpha = cos(geo.alpha);
+    sin_theta = sin(geo.theta);
+    cos_theta = cos(geo.theta);
+    sin_psi = sin(geo.psi);
+    cos_psi = cos(geo.psi);
     
-    point->x = auxPoint.x*(cos(geo.psi)*cos(geo.theta)*cos(geo.alpha)-sin(geo.psi)*sin(geo.alpha))
-    +auxPoint.y*(-cos(geo.psi)*cos(geo.theta)*sin(geo.alpha)-sin(geo.psi)*cos(geo.alpha))
-    +auxPoint.z*cos(geo.psi)*sin(geo.theta);
-    point->y = auxPoint.x*(sin(geo.psi)*cos(geo.theta)*cos(geo.alpha)+cos(geo.psi)*sin(geo.alpha))
-    +auxPoint.y*(-sin(geo.psi)*cos(geo.theta)*sin(geo.alpha)+cos(geo.psi)*cos(geo.alpha))
-    +auxPoint.z*sin(geo.psi)*sin(geo.theta);
-    point->z =-auxPoint.x*sin(geo.theta)*cos(geo.alpha)
-    +auxPoint.y*sin(geo.theta)*sin(geo.alpha)
-    +auxPoint.z*cos(geo.theta);
+    point->x = auxPoint.x*(cos_psi*cos_theta*cos_alpha-sin_psi*sin_alpha)
+    +auxPoint.y*(-cos_psi*cos_theta*sin_alpha-sin_psi*cos_alpha)
+    +auxPoint.z*cos_psi*sin_theta;
+    point->y = auxPoint.x*(sin_psi*cos_theta*cos_alpha+cos_psi*sin_alpha)
+    +auxPoint.y*(-sin_psi*cos_theta*sin_alpha+cos_psi*cos_alpha)
+    +auxPoint.z*sin_psi*sin_theta;
+    point->z =-auxPoint.x*sin_theta*cos_alpha
+    +auxPoint.y*sin_theta*sin_alpha
+    +auxPoint.z*cos_theta;
 }
 void rollPitchYawT(Geometry geo,int i, Point3D* point){
     Point3D auxPoint;
     auxPoint.x=point->x;
     auxPoint.y=point->y;
     auxPoint.z=point->z;
+
+    float sin_dRoll, cos_dRoll, sin_dPitch, cos_dPitch, sin_dYaw, cos_dYaw;
+    sin_dRoll = sin(geo.dRoll[i]);
+    cos_dRoll = cos(geo.dRoll[i]);
+    sin_dPitch = sin(geo.dPitch[i]);
+    cos_dPitch = cos(geo.dPitch[i]);
+    sin_dYaw = sin(geo.dYaw[i]);
+    cos_dYaw = cos(geo.dYaw[i]);
     
-    point->x=cos(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
-            +sin(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.y
-            -sin(geo.dPitch[i])*auxPoint.z;
+    point->x=cos_dRoll*cos_dPitch*auxPoint.x
+            +sin_dRoll*cos_dPitch*auxPoint.y
+            -sin_dPitch*auxPoint.z;
     
     
-    point->y=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) - sin(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.x
-            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) + cos(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
-            +cos(geo.dPitch[i])*sin(geo.dYaw[i])*auxPoint.z;
+    point->y=(cos_dRoll*sin_dPitch*sin_dYaw - sin_dRoll*cos_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*sin_dYaw + cos_dRoll*cos_dYaw)*auxPoint.y
+            +cos_dPitch*sin_dYaw*auxPoint.z;
     
     
-    point->z=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) + sin(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.x
-            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) - cos(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.y
-            +cos(geo.dPitch[i])*cos(geo.dYaw[i])*auxPoint.z;
+    point->z=(cos_dRoll*sin_dPitch*cos_dYaw + sin_dRoll*sin_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*cos_dYaw - cos_dRoll*sin_dYaw)*auxPoint.y
+            +cos_dPitch*cos_dYaw*auxPoint.z;
     
 }
 void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -759,7 +759,7 @@ void freeGeoArray(unsigned int splits,Geometry* geoArray){
 //      double precision functions for rotating Point3Ddouble coordinates
 //______________________________________________________________________________
 
-void eulerZYZT_double(Geometry geo, Point3Ddouble* point){
+void eulerZYZT(Geometry geo, Point3Ddouble* point){
     
     Point3Ddouble auxPoint;
     auxPoint.x=point->x;
@@ -786,7 +786,7 @@ void eulerZYZT_double(Geometry geo, Point3Ddouble* point){
     +auxPoint.z*cos_theta;
 }
 
-void rollPitchYawT_double(Geometry geo,int i, Point3Ddouble* point){
+void rollPitchYawT(Geometry geo,int i, Point3Ddouble* point){
 
     Point3Ddouble auxPoint;
     auxPoint.x=point->x;
@@ -840,10 +840,10 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     Px.z=P.z;                   Py.z=P.z;                Pz.z=P.z+geo.dVoxelZ;
     
     // Rotate image around X axis (this is equivalent of rotating the source and detector) RZ RY RZ
-    eulerZYZT_double(geo,&P);
-    eulerZYZT_double(geo,&Px);
-    eulerZYZT_double(geo,&Py);
-    eulerZYZT_double(geo,&Pz);
+    eulerZYZT(geo,&P);
+    eulerZYZT(geo,&Px);
+    eulerZYZT(geo,&Py);
+    eulerZYZT(geo,&Pz);
     
     //detector offset
     P.z =P.z-geo.offDetecV[i];            P.y =P.y-geo.offDetecU[i];
@@ -859,10 +859,10 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
     Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
     Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
-    rollPitchYawT_double(geo,i,&P);
-    rollPitchYawT_double(geo,i,&Px);
-    rollPitchYawT_double(geo,i,&Py);
-    rollPitchYawT_double(geo,i,&Pz);
+    rollPitchYawT(geo,i,&P);
+    rollPitchYawT(geo,i,&Px);
+    rollPitchYawT(geo,i,&Py);
+    rollPitchYawT(geo,i,&Pz);
     
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
@@ -873,7 +873,7 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     source.x=geo.DSD[i]; //already offseted for rotation
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
-    rollPitchYawT_double(geo,i,&source);
+    rollPitchYawT(geo,i,&source);
     
     source.x=source.x-(geo.DSD[i]-geo.DSO[i]);//   source.y=source.y-auxOff.y;    source.z=source.z-auxOff.z;
     
@@ -897,60 +897,6 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     *S=source.to_float();
 }
 
-void eulerZYZT(Geometry geo, Point3D* point){
-    
-    Point3D auxPoint;
-    auxPoint.x=point->x;
-    auxPoint.y=point->y;
-    auxPoint.z=point->z;
-
-    float sin_alpha, cos_alpha, sin_theta, cos_theta, sin_psi, cos_psi;
-    sin_alpha = sin(geo.alpha);
-    cos_alpha = cos(geo.alpha);
-    sin_theta = sin(geo.theta);
-    cos_theta = cos(geo.theta);
-    sin_psi = sin(geo.psi);
-    cos_psi = cos(geo.psi);
-    
-    point->x = auxPoint.x*(cos_psi*cos_theta*cos_alpha-sin_psi*sin_alpha)
-    +auxPoint.y*(-cos_psi*cos_theta*sin_alpha-sin_psi*cos_alpha)
-    +auxPoint.z*cos_psi*sin_theta;
-    point->y = auxPoint.x*(sin_psi*cos_theta*cos_alpha+cos_psi*sin_alpha)
-    +auxPoint.y*(-sin_psi*cos_theta*sin_alpha+cos_psi*cos_alpha)
-    +auxPoint.z*sin_psi*sin_theta;
-    point->z =-auxPoint.x*sin_theta*cos_alpha
-    +auxPoint.y*sin_theta*sin_alpha
-    +auxPoint.z*cos_theta;
-}
-void rollPitchYawT(Geometry geo,int i, Point3D* point){
-    Point3D auxPoint;
-    auxPoint.x=point->x;
-    auxPoint.y=point->y;
-    auxPoint.z=point->z;
-
-    float sin_dRoll, cos_dRoll, sin_dPitch, cos_dPitch, sin_dYaw, cos_dYaw;
-    sin_dRoll = sin(geo.dRoll[i]);
-    cos_dRoll = cos(geo.dRoll[i]);
-    sin_dPitch = sin(geo.dPitch[i]);
-    cos_dPitch = cos(geo.dPitch[i]);
-    sin_dYaw = sin(geo.dYaw[i]);
-    cos_dYaw = cos(geo.dYaw[i]);
-    
-    point->x=cos_dRoll*cos_dPitch*auxPoint.x
-            +sin_dRoll*cos_dPitch*auxPoint.y
-            -sin_dPitch*auxPoint.z;
-    
-    
-    point->y=(cos_dRoll*sin_dPitch*sin_dYaw - sin_dRoll*cos_dYaw)*auxPoint.x
-            +(sin_dRoll*sin_dPitch*sin_dYaw + cos_dRoll*cos_dYaw)*auxPoint.y
-            +cos_dPitch*sin_dYaw*auxPoint.z;
-    
-    
-    point->z=(cos_dRoll*sin_dPitch*cos_dYaw + sin_dRoll*sin_dYaw)*auxPoint.x
-            +(sin_dRoll*sin_dPitch*cos_dYaw - cos_dRoll*sin_dYaw)*auxPoint.y
-            +cos_dPitch*cos_dYaw*auxPoint.z;
-    
-}
 void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){
     size_t memfree;
     size_t memtotal;

--- a/Common/CUDA/voxel_backprojection.hpp
+++ b/Common/CUDA/voxel_backprojection.hpp
@@ -48,10 +48,10 @@ Codes  : https://github.com/CERN/TIGRE
 
 #ifndef BACKPROJECTION_HPP
 #define BACKPROJECTION_HPP
-void rollPitchYawT(Geometry geo,int i, Point3D* point);
+void rollPitchYawT(Geometry geo,int i, Point3Ddouble* point);
 int  voxel_backprojection(float* projections, Geometry geo, float* result,float const * const alphas,int nalpha, const GpuIds& gpuids);
 void splitCTbackprojection(const GpuIds& gpuids,Geometry geo,int nalpha, unsigned int* split_image, unsigned int * split_projections);
-void eulerZYZT(Geometry geo, Point3D* point);
+void eulerZYZT(Geometry geo, Point3Ddouble* point);
 void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S);
 void createGeoArray(unsigned int image_splits, Geometry geo,Geometry* geoArray, unsigned int nangles);
 void freeGeoArray(unsigned int splits,Geometry* geoArray);

--- a/Common/CUDA/voxel_backprojection2.cu
+++ b/Common/CUDA/voxel_backprojection2.cu
@@ -740,68 +740,6 @@ void splitCTbackprojection(const GpuIds& gpuids, Geometry geo,int nalpha, unsign
 }
 
 
-//______________________________________________________________________________
-//
-//      double precision functions for rotating Point3Ddouble coordinates
-//______________________________________________________________________________
-
-void eulerZYZT_double(Geometry geo, Point3Ddouble* point){
-    
-    Point3Ddouble auxPoint;
-    auxPoint.x=point->x;
-    auxPoint.y=point->y;
-    auxPoint.z=point->z;
-
-    // calculate sin and cos of 3 angles (used multiple times)
-    double sin_alpha, cos_alpha, sin_theta, cos_theta, sin_psi, cos_psi;
-    sin_alpha = sin((double)geo.alpha);
-    cos_alpha = cos((double)geo.alpha);
-    sin_theta = sin((double)geo.theta);
-    cos_theta = cos((double)geo.theta);
-    sin_psi = sin((double)geo.psi);
-    cos_psi = cos((double)geo.psi);
-    
-    point->x = auxPoint.x*(cos_psi*cos_theta*cos_alpha-sin_psi*sin_alpha)
-    +auxPoint.y*(-cos_psi*cos_theta*sin_alpha-sin_psi*cos_alpha)
-    +auxPoint.z*cos_psi*sin_theta;
-    point->y = auxPoint.x*(sin_psi*cos_theta*cos_alpha+cos_psi*sin_alpha)
-    +auxPoint.y*(-sin_psi*cos_theta*sin_alpha+cos_psi*cos_alpha)
-    +auxPoint.z*sin_psi*sin_theta;
-    point->z =-auxPoint.x*sin_theta*cos_alpha
-    +auxPoint.y*sin_theta*sin_alpha
-    +auxPoint.z*cos_theta;
-}
-
-void rollPitchYawT_double(Geometry geo,int i, Point3Ddouble* point){
-
-    Point3Ddouble auxPoint;
-    auxPoint.x=point->x;
-    auxPoint.y=point->y;
-    auxPoint.z=point->z;
-
-    // calculate sin and cos of 3 angles (used multiple times)
-    double sin_dRoll, cos_dRoll, sin_dPitch, cos_dPitch, sin_dYaw, cos_dYaw;
-    sin_dRoll = sin((double)geo.dRoll[i]);
-    cos_dRoll = cos((double)geo.dRoll[i]);
-    sin_dPitch = sin((double)geo.dPitch[i]);
-    cos_dPitch = cos((double)geo.dPitch[i]);
-    sin_dYaw = sin((double)geo.dYaw[i]);
-    cos_dYaw = cos((double)geo.dYaw[i]);
-    
-    point->x=cos_dRoll*cos_dPitch*auxPoint.x
-            +sin_dRoll*cos_dPitch*auxPoint.y
-            -sin_dPitch*auxPoint.z;
-    
-    point->y=(cos_dRoll*sin_dPitch*sin_dYaw - sin_dRoll*cos_dYaw)*auxPoint.x
-            +(sin_dRoll*sin_dPitch*sin_dYaw + cos_dRoll*cos_dYaw)*auxPoint.y
-            +cos_dPitch*sin_dYaw*auxPoint.z;
-    
-    point->z=(cos_dRoll*sin_dPitch*cos_dYaw + sin_dRoll*sin_dYaw)*auxPoint.x
-            +(sin_dRoll*sin_dPitch*cos_dYaw - cos_dRoll*sin_dYaw)*auxPoint.y
-            +cos_dPitch*cos_dYaw*auxPoint.z;
-}
-
-
 void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S)
 {
     Point3Ddouble P, Px,Py,Pz;
@@ -819,10 +757,10 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     
 // Rotate image around X axis (this is equivalent of rotating the source and detector) RZ RY RZ
     
-    eulerZYZT_double(geo,&P);
-    eulerZYZT_double(geo,&Px);
-    eulerZYZT_double(geo,&Py);
-    eulerZYZT_double(geo,&Pz);
+    eulerZYZT(geo,&P);
+    eulerZYZT(geo,&Px);
+    eulerZYZT(geo,&Py);
+    eulerZYZT(geo,&Pz);
     
     
     
@@ -841,10 +779,10 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
     Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
     Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
-    rollPitchYawT_double(geo,i,&P);
-    rollPitchYawT_double(geo,i,&Px);
-    rollPitchYawT_double(geo,i,&Py);
-    rollPitchYawT_double(geo,i,&Pz);
+    rollPitchYawT(geo,i,&P);
+    rollPitchYawT(geo,i,&Px);
+    rollPitchYawT(geo,i,&Py);
+    rollPitchYawT(geo,i,&Pz);
     
     P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
     Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
@@ -855,7 +793,7 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     source.x=geo.DSD[i]; //already offseted for rotation
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
-    rollPitchYawT_double(geo,i,&source);
+    rollPitchYawT(geo,i,&source);
     
     
     source.x=source.x-(geo.DSD[i]-geo.DSO[i]);//   source.y=source.y-auxOff.y;    source.z=source.z-auxOff.z;
@@ -880,27 +818,6 @@ void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, 
     *S=source.to_float();
 }  // END computeDeltasCube
 
-void rollPitchYawT(Geometry geo,int i, Point3D* point){
-    Point3D auxPoint;
-    auxPoint.x=point->x;
-    auxPoint.y=point->y;
-    auxPoint.z=point->z;
-    
-    point->x=cos(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.x
-            +sin(geo.dRoll[i])*cos(geo.dPitch[i])*auxPoint.y
-            -sin(geo.dPitch[i])*auxPoint.z;
-    
-    
-    point->y=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) - sin(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.x
-            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*sin(geo.dYaw[i]) + cos(geo.dRoll[i])*cos(geo.dYaw[i]))*auxPoint.y
-            +cos(geo.dPitch[i])*sin(geo.dYaw[i])*auxPoint.z;
-    
-    
-    point->z=(cos(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) + sin(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.x
-            +(sin(geo.dRoll[i])*sin(geo.dPitch[i])*cos(geo.dYaw[i]) - cos(geo.dRoll[i])*sin(geo.dYaw[i]))*auxPoint.y
-            +cos(geo.dPitch[i])*cos(geo.dYaw[i])*auxPoint.z;
-    
-}
 void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){
     size_t memfree;
     size_t memtotal;

--- a/Common/CUDA/voxel_backprojection_parallel.cu
+++ b/Common/CUDA/voxel_backprojection_parallel.cu
@@ -507,7 +507,7 @@ int voxel_backprojection_parallel(float  *  projections, Geometry geo, float* re
 void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D *S)
 {
     
-    Point3D P, Px,Py,Pz;
+    Point3Ddouble P, Px,Py,Pz;
     // Get coords of Img(0,0,0)
     P.x=-(geo.sVoxelX/2-geo.dVoxelX/2)+geo.offOrigX[i];
     P.y=-(geo.sVoxelY/2-geo.dVoxelY/2)+geo.offOrigY[i];
@@ -553,7 +553,7 @@ void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D*
     Pz.x=Pz.x-(geo.DSD[i]-geo.DSO[i]);
     
     
-    Point3D source;
+    Point3Ddouble source;
     source.x=0;
     source.y=-geo.offDetecU[i];
     source.z=-geo.offDetecV[i];
@@ -574,8 +574,10 @@ void computeDeltasCubeParallel(Geometry geo, int i, Point3D* xyzorigin, Point3D*
     deltaZ->x=Pz.x-P.x;   deltaZ->y=Pz.y-P.y;    deltaZ->z=Pz.z-P.z;
     
     
-    *xyzorigin=P;
-    *S=source;
+    // cast the results from the double precision calculations back to float
+    *xyzorigin=P.to_float();
+    *S=source.to_float();
+
     
 }  // END computeDeltasCube
 void CreateTextureParallel(float* projectiondata,Geometry geo,cudaArray** d_cuArrTex,unsigned int nangles, cudaTextureObject_t *texImage,cudaStream_t* stream, bool alloc)


### PR DESCRIPTION
Changed the function computeDeltasCube() in voxel_backprojection.cu to double precision, including double precision versions of coordinate rotation functions. Added a double precision Point3Ddouble struct to types_TIGRE.hpp. Integrated the computeDeltas_Siddon() function in Siddon_projection.cu from [IbexInnovations](https://github.com/IbexInnovations/TIGRE/blob/8d8c8eb4e7be922a69512baa08b4dad5bf516cc3/Common/CUDA/Siddon_projection.cu#L680) related to issue https://github.com/CERN/TIGRE/issues/355.