### PR TITLE
Fix bug related to ComputeV for PICCS algorithm

### DIFF
--- a/MATLAB/Algorithms/PICCS.m
+++ b/MATLAB/Algorithms/PICCS.m
@@ -135,7 +135,7 @@ while ~stop_criteria %POCS
         %         weigth_backprj=bsxfun(@times,1./V(:,:,jj),backprj); %                 V * At * W^-1 * (b-Ax)
         %         f=f+beta*weigth_backprj;                          % x= x + lambda * V * At * W^-1 * (b-Ax)
         % Enforce positivity
-        f=f+beta* bsxfun(@times,1./V(:,:,index_angles(:,jj)),Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(f,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'gpuids',gpuids));
+        f= f+beta* bsxfun(@times,1./V(:,:,jj),Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(f,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'gpuids',gpuids));
         % non-negativity constrain
         if nonneg
             f=max(f,0);
@@ -199,7 +199,7 @@ while ~stop_criteria %POCS
     end
     if (iter==1 && verbose==1)
         expected_time=toc*maxiter;
-        disp('ADS-POCS');
+        disp('PICCS');
         disp(['Expected duration  :    ',secs2hms(expected_time)]);
         disp(['Exected finish time:    ',datestr(datetime('now')+seconds(expected_time))]);
         disp('');


### PR DESCRIPTION
Hi @AnderBiguri 

I encountered an issue with the new version of the ComputeV function while working with TIGRE and running the PICCS algorithm. The new function works well for ASD_POCS but not for PICCS. To resolve this, I used the body of the old ComputeV function with the new function definition. This modification seems to work for all algorithms, including PICCS.

Could you please review the changes and verify if they are suitable for the repository?

Thank you!