### PR TITLE
Update pyproject.toml python version to <3.12 instead of <=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors=[
 	{name = "Sam Loescher"},
 ]
 license={text="BSD 3-Clause"}
-requires-python = ">=3.7,<=3.11"
+requires-python = ">=3.7,<3.12"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
For some reason my docker build failes on python version <=3.11 (I am using python 3.11.12), while it succeeds with python version to <3.12