### PR TITLE
update gcc version number

### DIFF
--- a/Frontispiece/python_installation.md
+++ b/Frontispiece/python_installation.md
@@ -89,7 +89,7 @@ Tested on
 |**Ubuntu**| 16.04>|
 |**Python**| 3.7-3.11|
 |**CUDA**| 9.2>|
-|**gcc**|  7.6.0|
+|**gcc**|  7.5.0|
 
 ### Simple Instructions
 


### PR DESCRIPTION
I was able to find `gcc_linux-64=7.5.0` through the conda-forge channel, but not version 7.6.0. With that TIGRE successfully built, so I think that is a viable option. The prior version I tried, 14.3.0, the version I got without specifying a version in my conda `environment.yml` file led to errors in the build process.