### PR TITLE
Numpy 2.3.0+ compatibility, NPY_OWNDATA to NPY_ARRAY_OWNDATA

### DIFF
--- a/Python/tigre/utilities/cuda_interface/_Atb.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Atb.pyx
@@ -82,7 +82,7 @@ def _Atb_ext(np.ndarray[np.float32_t, ndim=3] projections, geometry, np.ndarray[
 
     # TODO: Swap axis here could be making a copy
     model = np.PyArray_SimpleNewFromData(3, shape, np.NPY_FLOAT32, c_model)
-    PyArray_ENABLEFLAGS(model, np.NPY_OWNDATA) # Attribute new memory owner
+    PyArray_ENABLEFLAGS(model, np.NPY_ARRAY_OWNDATA) # Attribute new memory owner
 
     free_c_geometry(c_geometry)
 

--- a/Python/tigre/utilities/cuda_interface/_AwminTV.pyx
+++ b/Python/tigre/utilities/cuda_interface/_AwminTV.pyx
@@ -54,6 +54,6 @@ def AwminTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter 
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
     aw_pocs_tv(c_src, c_imgout, alpha, imgsize, c_maxiter, delta, c_gpuids[0])
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
-    PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(imgout, np.NPY_ARRAY_OWNDATA)
 
     return imgout

--- a/Python/tigre/utilities/cuda_interface/_Ax.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Ax.pyx
@@ -93,7 +93,7 @@ def _Ax_ext(np.ndarray[np.float32_t, ndim=3] img, geometry, np.ndarray[np.float3
     shape[2] = <np.npy_intp> (<np.npy_long>(geometry.nDetector[1]))
 
     projections = np.PyArray_SimpleNewFromData(3, shape, np.NPY_FLOAT32, c_projectionsNonPinned)
-    PyArray_ENABLEFLAGS(projections, np.NPY_OWNDATA)  # Attribute new memory owner
+    PyArray_ENABLEFLAGS(projections, np.NPY_ARRAY_OWNDATA)  # Attribute new memory owner
 
     free(c_projections)  # Free pointer array, not actual data
     free_c_geometry(c_geometry)

--- a/Python/tigre/utilities/cuda_interface/_minTV.pyx
+++ b/Python/tigre/utilities/cuda_interface/_minTV.pyx
@@ -59,6 +59,6 @@ def minTV(np.ndarray[np.float32_t, ndim=3] src,float alpha = 15.0,int maxiter = 
     cdef np.npy_intp c_maxiter = <np.npy_intp> maxiter
     cuda_raise_errors(pocs_tv(c_src, c_imgout, alpha, imgsize, c_maxiter, c_gpuids[0]))
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
-    PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(imgout, np.NPY_ARRAY_OWNDATA)
     
     return imgout

--- a/Python/tigre/utilities/cuda_interface/_randomNumberGenerator.pyx
+++ b/Python/tigre/utilities/cuda_interface/_randomNumberGenerator.pyx
@@ -58,7 +58,7 @@ def add_poisson(np.ndarray[np.float32_t, ndim=3] src, gpuids=None):
     cdef np.npy_intp c_uiSigLen = <np.npy_intp> (size_img[0] *size_img[1] *size_img[2])
     cuda_raise_errors(poisson_1d(c_src, c_uiSigLen, c_imgout, c_gpuids[0]))
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
-    PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(imgout, np.NPY_ARRAY_OWNDATA)
     
     return imgout
 
@@ -91,6 +91,6 @@ def add_noise(np.ndarray[np.float32_t, ndim=3] poisson_lambda,
     cdef np.float32_t c_fGaussSigma = gaussian_sigma
     cuda_raise_errors(poisson_gaussian_1d(c_src, c_uiSigLen, c_fGaussMu, c_fGaussSigma, c_imgout, c_gpuids[0]))
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
-    PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(imgout, np.NPY_ARRAY_OWNDATA)
     
     return imgout

--- a/Python/tigre/utilities/cuda_interface/_tv_proximal.pyx
+++ b/Python/tigre/utilities/cuda_interface/_tv_proximal.pyx
@@ -66,6 +66,6 @@ def tvdenoise(np.ndarray[np.float32_t, ndim=3] src, int maxiter = 100, float lam
     cuda_raise_errors(tvdenoising(c_src, c_imgout, lamda, spacing, imgsize, c_maxiter, c_gpuids[0]))
 
     imgout = np.PyArray_SimpleNewFromData(3, size_img, np.NPY_FLOAT32, c_imgout)
-    PyArray_ENABLEFLAGS(imgout, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(imgout, np.NPY_ARRAY_OWNDATA)
 
     return imgout


### PR DESCRIPTION
This addresses #676 
The macro `NPY_OWNDATA` has been deprecated since numpy 1.7 and was removed completely in 2.3.0. 
The replacement `NPY_ARRAY_OWNDATA` has been available since numpy 1.7. 
Given that the minimum numpy version required by TIGRE is 1.20 this change should be backwards compatible for anyone using an older supported version of numpy with TIGRE.