### PR TITLE
Fix Python interface for NumPy 2.4.0 and above

### DIFF
--- a/Python/tigre/utilities/geometry.py
+++ b/Python/tigre/utilities/geometry.py
@@ -140,7 +140,7 @@ class Geometry(object):
         old_attrib = getattr(self, attrib)
 
         if type(old_attrib) in [float, int, np.float32, np.float64, np.int32]:
-            new_attrib = np.tile(old_attrib, (angles.shape[0], 1))
+            new_attrib = np.tile(old_attrib, angles.shape[0])
             setattr(self, attrib, new_attrib)
 
         elif type(old_attrib) == np.ndarray:


### PR DESCRIPTION
NumPy 2.4.0 [removed a depreciated implicit conversion of arrays to scalars](https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar), raising a TypeError instead.  This was being triggered at runtime in _types.pxd, where TIGRE was attempting copy single-value numpy arrays to the C++ versions of DSD, DSO and COR, rather than the value itself.

I fixed this by modifying the __check_and_repmat__ function in geometry.py, to reshape DSD, DSO and COR to be an array of values, rather than an array of arrays.

An alternative approach would be to explicitly return the value in _types.pxd, by using for example DSD.item(i) instead of DSD[i], but making a small change to geometry.py seems cleaner, and doesn't affect anything else as these 3 Python arrays are only accessed in _types.pxd.