### PR TITLE
Add utility to mask CBCT FOV and remove cylindrical background

### DIFF
--- a/Python/tigre/utilities/mask_CBCT.py
+++ b/Python/tigre/utilities/mask_CBCT.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+def maskCBCT(img):
+    """
+    Apply cylindrical CBCT FOV mask to a reconstructed volume.
+
+    Parameters
+    ----------
+    img : ndarray
+        Reconstructed volume in (Z, Y, X) order.
+
+    Returns
+    -------
+    img_masked : ndarray
+        Volume with voxels outside CBCT FOV set to zero.
+    """
+    Nz, Ny, Nx = img.shape
+    cx, cy = Nx // 2, Ny // 2
+    radius = min(cx, cy)
+
+    Y, X = np.ogrid[:Ny, :Nx]
+    dist = np.sqrt((X - cx)**2 + (Y - cy)**2)
+    mask2d = dist <= radius
+
+    img_masked = img.copy()
+    for z in range(Nz):
+        img_masked[z][~mask2d] = 0.0
+
+    return img_masked


### PR DESCRIPTION
### Description

This PR adds a small optional utility function to explicitly mask the CBCT field-of-view in FDK reconstructed volumes.

Users frequently observe a cylindrical surface in 3D isosurface rendering, especially for low-density objects close to air. This surface corresponds to the valid CBCT FOV and is currently removed only implicitly by commercial software.

The added utility mirrors common commercial post-processing by zeroing voxels outside the CBCT FOV, without modifying reconstruction algorithms or defaults.

### Motivation

Related discussion: Issue #701

### Impact

- No change to existing behavior
- Purely optional post-processing
- Improves user experience and reduces confusion
