### PR TITLE
Fix license line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors=[
 	{name = "Reuben Lindroos"}, 
 	{name = "Sam Loescher"},
 ]
-license="BSD-3-Clause"
+license={text="BSD-3-Clause"}
 requires-python = ">=3.7,<3.12"
 
 [dependency-groups]


### PR DESCRIPTION
Specify `text=` before the Licence Expression, otherwise it returns the error `configuration error: `project.license` must be valid exactly by one definition (2 matches found)` on install