### PR TITLE
Fix plot_geometry error

### DIFF
--- a/Python/tigre/utilities/visualization/plot_geometry.py
+++ b/Python/tigre/utilities/visualization/plot_geometry.py
@@ -1,7 +1,10 @@
 import matplotlib.patches
 import numpy as np
 import tigre
-from mpl_toolkits.mplot3d import art3d
+import mpl_toolkits.mplot3d.art3d as art3d
+
+if not hasattr(art3d.PathPatch3D, "_axlim_clip"):
+    art3d.PathPatch3D._axlim_clip = False
 
 # https://matplotlib.org/mpl_toolkits/mplot3d/tutorial.html
 


### PR DESCRIPTION
Solution taken from:
https://github.com/CERN/TIGRE/issues/624#issuecomment-2998595435

The error message was:
```log
python-BaseException
Traceback (most recent call last):
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\backends\backend_agg.py", line 382, in draw
    self.figure.draw(self.renderer)
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\artist.py", line 94, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\figure.py", line 3257, in draw
    mimage._draw_list_compositing_images(
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\image.py", line 134, in _draw_list_compositing_images
    a.draw(renderer)
  File "M:\Dev\TAIR\.venv\lib\site-packages\matplotlib\artist.py", line 71, in draw_wrapper
    return draw(artist, renderer)
  File "M:\Dev\TAIR\.venv\lib\site-packages\mpl_toolkits\mplot3d\axes3d.py", line 445, in draw
    for artist in sorted(collections_and_patches,
  File "M:\Dev\TAIR\.venv\lib\site-packages\mpl_toolkits\mplot3d\axes3d.py", line 446, in <lambda>
    key=lambda artist: artist.do_3d_projection(),
  File "M:\Dev\TAIR\.venv\lib\site-packages\mpl_toolkits\mplot3d\art3d.py", line 589, in do_3d_projection
    if self._axlim_clip:
AttributeError: 'PathPatch3D' object has no attribute '_axlim_clip'
```
Closes #624.