### PR TITLE
fix for #741

### DIFF
--- a/Python/tigre/algorithms/iterative_recon_alg.py
+++ b/Python/tigre/algorithms/iterative_recon_alg.py
@@ -328,14 +328,10 @@ class IterativeReconAlg(object):
 
         for j in range(len(self.angleblocks)):
 
-            if self.blocksize == 1:
-                angle = np.array([self.angleblocks[j]], dtype=np.float32)
-                angle_indices = np.array([self.angle_index[j]], dtype=np.int32)
+            angle = self.angleblocks[j]
+            angle_indices = self.angle_index[j]
 
-            else:
-                angle = self.angleblocks[j]
-                angle_indices = self.angle_index[j]
-                # slice parameters if needed
+            # slice parameters if needed
             geo.offOrigin = self.geo.offOrigin[angle_indices]
             geo.offDetector = self.geo.offDetector[angle_indices]
             geo.rotDetector = self.geo.rotDetector[angle_indices]


### PR DESCRIPTION
I encountered the same issue as mentioned in #741, and resolved it by removing the blocksize == 1 case. When Ax is called [on line 399 of `update_image` in `iterative_rec_alg.py`](https://github.com/CERN/TIGRE/blob/f04b52757b6b3c7cf00dc3f40066e14984a0abb6/Python/tigre/algorithms/iterative_recon_alg.py#L399), `angle = np.array([self.angleblocks[j]], dtype=np.float32)` creates an extra dimension which does not play well with [`c_geom.DSO[i] = p_geometry.DSO[i]`](https://github.com/CERN/TIGRE/blob/f04b52757b6b3c7cf00dc3f40066e14984a0abb6/Python/tigre/utilities/cuda_interface/_types.pxd#L103) which expects a scalar.

This nature of expected number of dimensions also affects for example [`Python/demos/d09_Algorithms04.py`](https://github.com/CERN/TIGRE/blob/f04b52757b6b3c7cf00dc3f40066e14984a0abb6/Python/demos/d09_Algorithms04.py#L207): `    delta=np.array([-0.005]),` which needs to be changed to `    delta=np.array(-0.005, dtype=np.float32),`. I've not made this change, because I don't know where else such problems exist, but I hope that this change fixes this issue.