### PR TITLE
Improve Parker weighting detection robustness for near-360° scans

### DIFF
--- a/MATLAB/Algorithms/FDK.m
+++ b/MATLAB/Algorithms/FDK.m
@@ -153,7 +153,7 @@ for ii=1:length(opts)
         case 'parker'
             if default
                 if size(angles,1)==1 || (all(angles(2,:)==0) && all(angles(3,:)==0))
-                    parker=max(angles(1,:))-min(angles(1,:))<(2*pi-max(diff(angles(1,:))));
+                    parker=max(angles(1,:))-min(angles(1,:))<(2*pi-1.5*max(diff(angles(1,:))));
                 else
                     parker=false;
                 end


### PR DESCRIPTION
This PR improves the automatic Parker weighting detection in the FDK reconstruction.

The previous condition could incorrectly classify a nearly complete 360° scan as a short scan due to small numerical errors or slight angular sampling inconsistencies.

This modification introduces a tolerance of half an angular interval. In other words, if the missing angular coverage is within 0.5× the maximum angular step, the scan is still treated as a full 360° scan rather than enabling Parker weighting unnecessarily.

This improves robustness while preserving correct short-scan detection.

This issue was observed during 16× and higher sparse-view reconstructions using the [photon-counting CT walnut dataset](https://www.nature.com/articles/s41597-025-06246-4) in [WalnutPCCTReconCodes](https://github.com/zezisme/WalnutPCCTReconCodes)（built on TIGRE）, where 360° scans could be incorrectly identified as short scans, unintentionally triggering Parker weighting.

<img width="1192" height="725" alt="image" src="https://github.com/user-attachments/assets/1dbeeb0d-1713-4361-86ba-966db95f0238" />

