### PR TITLE
[ROCm] Add AMD GPU support to the Python backend

### DIFF
--- a/Common/CUDA/GD_AwTV.cu
+++ b/Common/CUDA/GD_AwTV.cu
@@ -54,6 +54,7 @@
 #define MAXTHREADS 1024
 #define MAX_BUFFER 60
 
+#include "cuda_to_hip.h"
 #include "GD_AwTV.hpp"
 
 
@@ -541,7 +542,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
                         size_t dimgridRed = (total_pixels + MAXTHREADS - 1) / MAXTHREADS;
                         
                         cudaStreamSynchronize(stream[dev*nStream_device+1]);
-                        reduceNorm2 << <dimgridRed, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device]>> >(d_norm2[dev], d_norm2aux[dev], total_pixels);
+                        reduceNorm2 <<<dimgridRed, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device]>>>(d_norm2[dev], d_norm2aux[dev], total_pixels);
                         
                     }
                     for (dev = 0; dev < deviceCount; dev++){
@@ -552,7 +553,7 @@ void aw_pocs_tv(float* img,float* dst,float alpha,const long* image_size, int ma
                         size_t dimgridRed = (total_pixels + MAXTHREADS - 1) / MAXTHREADS;
 
                         if (dimgridRed > 1) {
-                            reduceSum << <1, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device] >> >(d_norm2aux[dev], d_norm2[dev], dimgridRed);
+                            reduceSum <<<1, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device] >>>(d_norm2aux[dev], d_norm2[dev], dimgridRed);
                             cudaStreamSynchronize(stream[dev*nStream_device]);
                             cudaMemcpyAsync(&sumnorm2[dev], d_norm2[dev], sizeof(float), cudaMemcpyDeviceToHost,stream[dev*nStream_device+1]);
                         }

--- a/Common/CUDA/GD_TV.cu
+++ b/Common/CUDA/GD_TV.cu
@@ -54,6 +54,7 @@
 #define MAXTHREADS 1024
 #define MAX_BUFFER 60
 
+#include "cuda_to_hip.h"
 #include "GD_TV.hpp"
 #include "gpuUtils.hpp"
 
@@ -525,7 +526,7 @@ do { \
                         size_t dimgridRed = (total_pixels + MAXTHREADS - 1) / MAXTHREADS;
                         
                         cudaStreamSynchronize(stream[dev*nStream_device+1]);
-                        reduceNorm2 << <dimgridRed, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device]>> >(d_norm2[dev], d_norm2aux[dev], total_pixels);
+                        reduceNorm2 <<<dimgridRed, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device]>>>(d_norm2[dev], d_norm2aux[dev], total_pixels);
                         
                     }
                     for (dev = 0; dev < deviceCount; dev++){
@@ -536,7 +537,7 @@ do { \
                         size_t dimgridRed = (total_pixels + MAXTHREADS - 1) / MAXTHREADS;
 
                         if (dimgridRed > 1) {
-                            reduceSum << <1, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device] >> >(d_norm2aux[dev], d_norm2[dev], dimgridRed);
+                            reduceSum <<<1, dimblockRed, MAXTHREADS*sizeof(float),stream[dev*nStream_device] >>>(d_norm2aux[dev], d_norm2[dev], dimgridRed);
                             cudaStreamSynchronize(stream[dev*nStream_device]);
                             cudaMemcpyAsync(&sumnorm2[dev], d_norm2[dev], sizeof(float), cudaMemcpyDeviceToHost,stream[dev*nStream_device+1]);
                         }

--- a/Common/CUDA/GpuIds.cpp
+++ b/Common/CUDA/GpuIds.cpp
@@ -1,7 +1,7 @@
 #include "GpuIds.hpp"
 #include <stdlib.h>
 #include <string.h>
-#include <cuda_runtime_api.h>
+#include "cuda_to_hip.h"
 
 GpuIds::~GpuIds() {
     free(m_piDeviceIds); m_piDeviceIds = nullptr;

--- a/Common/CUDA/PICCS.cu
+++ b/Common/CUDA/PICCS.cu
@@ -53,6 +53,7 @@ Codes  : https://github.com/CERN/TIGRE
 
 #define MAXTHREADS 1024
 
+#include "cuda_to_hip.h"
 #include "PICCS.hpp"
 
 
@@ -350,11 +351,11 @@ bool isnan_cuda(float* vec, size_t size){
             //mexPrintf("Pre-norm2 is nan: %s\n",isnan_cuda(d_dimgTV,total_pixels) ? "true" : "false");
             cudaMemcpy(d_norm2, d_dimgTV, mem_size, cudaMemcpyDeviceToDevice);
             cudaCheckErrors("Copy from gradient call error");
-            reduceNorm2 << <dimgridRed, dimblockRed, MAXTHREADS*sizeof(float) >> >(d_norm2, d_aux_small, total_pixels);
+            reduceNorm2 <<<dimgridRed, dimblockRed, MAXTHREADS*sizeof(float) >>>(d_norm2, d_aux_small, total_pixels);
             cudaDeviceSynchronize();
             cudaCheckErrors("reduce1");
             if (dimgridRed > 1) {
-                reduceSum << <1, dimblockRed, MAXTHREADS*sizeof(float) >> >(d_aux_small, d_norm2, dimgridRed);
+                reduceSum <<<1, dimblockRed, MAXTHREADS*sizeof(float) >>>(d_aux_small, d_norm2, dimgridRed);
                 cudaDeviceSynchronize();
                 cudaCheckErrors("reduce2");
                 cudaMemcpy(&sumnorm2, d_norm2, sizeof(float), cudaMemcpyDeviceToHost);

--- a/Common/CUDA/RandomNumberGenerator.cu
+++ b/Common/CUDA/RandomNumberGenerator.cu
@@ -45,10 +45,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <cuda.h>
-#include <curand_kernel.h>
-#include <curand.h>
-
+#include "cuda_to_hip.h"
 #include "gpuUtils.hpp"
 #include "RandomNumberGenerator.hpp"
 

--- a/Common/CUDA/Siddon_projection.cu
+++ b/Common/CUDA/Siddon_projection.cu
@@ -48,8 +48,7 @@
  */
 
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "Siddon_projection.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -241,6 +240,14 @@ __global__ void kernelPixelDetector( Geometry geo,
     float maxlength=__fsqrt_rd(ray.x*ray.x*geo.dVoxelX*geo.dVoxelX+ray.y*ray.y*geo.dVoxelY*geo.dVoxelY+ray.z*ray.z*geo.dVoxelZ*geo.dVoxelZ);
     float sum=0.0f;
     unsigned long Np=(imax-imin+1)+(jmax-jmin+1)+(kmax-kmin+1); // Number of intersections
+    // A straight ray crosses at most (Nx+Ny+Nz) voxel-boundary planes. The
+    // index bounds above use exact float-equality tests on quantities formed
+    // with __fdividef, whose approximate result can differ enough between back
+    // ends to flip a test and yield a wildly out-of-range imax/jmax/kmax; the
+    // unsigned subtraction then makes Np astronomical and the loop runs for ~ever.
+    // Cap Np at the true geometric maximum: a no-op for any valid ray.
+    const unsigned long Np_max=(unsigned long)geo.nVoxelX+(unsigned long)geo.nVoxelY+(unsigned long)geo.nVoxelZ+3UL;
+    if (Np>Np_max) Np=Np_max;
     // Go iterating over the line, intersection by intersection. If double point, no worries, 0 will be computed
     i+=0.5f;
     j+=0.5f;

--- a/Common/CUDA/Siddon_projection_parallel.cu
+++ b/Common/CUDA/Siddon_projection_parallel.cu
@@ -50,8 +50,7 @@
 
 
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "Siddon_projection_parallel.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -244,6 +243,11 @@ __global__ void kernelPixelDetector_parallel( Geometry geo,
     float maxlength=sqrtf(ray.x*ray.x*geo.dVoxelX*geo.dVoxelX+ray.y*ray.y*geo.dVoxelY*geo.dVoxelY);//+ray.z*ray.z*geo.dVoxelZ*geo.dVoxelZ);
     float sum=0.0f;
     unsigned long Np=(imax-imin+1)+(jmax-jmin+1);//+(kmax-kmin+1); // Number of intersections
+    // See Siddon_projection.cu: cap Np at the geometric maximum so an
+    // out-of-range index bound (from an approximate-division float-equality
+    // flip) cannot make the loop run unbounded. A no-op for any valid ray.
+    const unsigned long Np_max=(unsigned long)geo.nVoxelX+(unsigned long)geo.nVoxelY+3UL;
+    if (Np>Np_max) Np=Np_max;
     // Go iterating over the line, intersection by intersection. If double point, no worries, 0 will be computed
     i+=0.5f;
     j+=0.5f;

--- a/Common/CUDA/cuda_to_hip.h
+++ b/Common/CUDA/cuda_to_hip.h
@@ -1,0 +1,290 @@
+/*-------------------------------------------------------------------------
+ *
+ * cuda_to_hip.h: CUDA -> HIP/ROCm compatibility shim for the Python/CUDA
+ * backend of TIGRE.
+ *
+ * When USE_HIP is defined (the BUILD_WITH_HIP branch in setup.py) this header
+ * maps the small set of CUDA runtime / cuRAND symbols the GPU sources use onto
+ * their hip* equivalents and provides a texture fetch (tex3D_TIGRE) that uses
+ * hardware trilinear filtering where available and a software lerp where it is
+ * not. On NVIDIA the header is a thin passthrough to the CUDA runtime, so the
+ * CUDA build is unchanged.
+ *
+ * fp32 element-read (cudaReadModeElementType) hardware linear filtering is not
+ * available on every ROCm / hardware combination: some reject creation of a
+ * cudaFilterModeLinear texture, others accept it but silently point-sample.
+ * tigre_hw_linear_supported() (in gpuUtils.cu) decides at runtime with a
+ * verified self-test -- it creates a tiny Linear ramp texture and confirms a
+ * known sample actually interpolates -- caches the verdict for the process and
+ * logs it once. On CUDA it returns true without testing.
+ *
+ * The backprojection kernels and the interpolated forward projector pick their
+ * texture filterMode from that verdict (Linear when supported, else Point), and
+ * tex3D_TIGRE mirrors it through the per-TU device flag tigre_hw_linear_filter:
+ * when supported it forwards to the hardware tex3D<float>; otherwise it point-
+ * samples the 8 neighbours through the point-filtered texture (border addressing
+ * returns 0 outside the array, matching cudaAddressModeBorder) and lerps with
+ * CUDA's unnormalized -0.5 texel-center convention. The texture's creation mode
+ * and the sampling path are both driven from the single cached verdict so they
+ * never disagree. tigre_sync_hw_linear() copies the verdict into this TU's
+ * device flag and must be called once after the texture is created.
+ *
+ * CODE by       Jeff Daily <jeff.daily@amd.com>
+ * ---------------------------------------------------------------------------
+ * ---------------------------------------------------------------------------
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * ---------------------------------------------------------------------------
+ *
+ * Contact: tigre.toolbox@gmail.com
+ * Codes  : https://github.com/CERN/TIGRE
+ * ---------------------------------------------------------------------------
+ */
+#ifndef CUDA_TO_HIP_H
+#define CUDA_TO_HIP_H
+
+#if defined(USE_HIP)
+
+/* Host string/alloc functions must resolve to the C library, not the HIP
+ * __device__ overloads, when a .cu is compiled as HIP host+device. */
+#include <cstring>
+#include <cstdlib>
+
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#else
+#include <hip/hip_runtime_api.h>
+#endif
+
+/* ---- runtime types / enums ---- */
+#define cudaArray                       hipArray
+#define cudaArray_t                     hipArray_t
+#define cudaExtent                      hipExtent
+#define cudaPitchedPtr                  hipPitchedPtr
+#define cudaPos                         hipPos
+#define cudaMemcpy3DParms               hipMemcpy3DParms
+#define cudaChannelFormatDesc           hipChannelFormatDesc
+#define cudaResourceDesc                hipResourceDesc
+#define cudaTextureDesc                 hipTextureDesc
+#define cudaTextureObject_t             hipTextureObject_t
+#define cudaStream_t                    hipStream_t
+#define cudaEvent_t                     hipEvent_t
+#define cudaError_t                     hipError_t
+#define cudaDeviceProp                  hipDeviceProp_t
+
+#define cudaResourceTypeArray           hipResourceTypeArray
+#define cudaReadModeElementType         hipReadModeElementType
+#define cudaFilterModePoint             hipFilterModePoint
+#define cudaFilterModeLinear            hipFilterModeLinear
+#define cudaAddressModeBorder           hipAddressModeBorder
+#define cudaAddressModeClamp            hipAddressModeClamp
+#define cudaAddressModeWrap             hipAddressModeWrap
+
+#define cudaMemcpyHostToDevice          hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost          hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice        hipMemcpyDeviceToDevice
+#define cudaMemcpyHostToHost            hipMemcpyHostToHost
+#define cudaMemcpyDefault               hipMemcpyDefault
+
+#define cudaSuccess                     hipSuccess
+#define cudaErrorMemoryAllocation       hipErrorOutOfMemory
+
+#define cudaHostRegisterPortable        hipHostRegisterPortable
+#define cudaDevAttrHostRegisterSupported hipDeviceAttributeHostRegisterSupported
+
+/* ---- runtime API ---- */
+#define cudaSetDevice                   hipSetDevice
+#define cudaGetDevice                   hipGetDevice
+#define cudaGetDeviceCount              hipGetDeviceCount
+#define cudaGetDeviceProperties         hipGetDeviceProperties
+#define cudaDeviceGetAttribute          hipDeviceGetAttribute
+#define cudaDeviceSynchronize           hipDeviceSynchronize
+#define cudaDeviceReset                 hipDeviceReset
+#define cudaGetLastError                hipGetLastError
+#define cudaPeekAtLastError             hipPeekAtLastError
+#define cudaGetErrorString              hipGetErrorString
+#define cudaMemGetInfo                  hipMemGetInfo
+
+#define cudaMalloc                      hipMalloc
+#define cudaFree                        hipFree
+#define cudaMallocHost                  hipHostMalloc
+#define cudaFreeHost                    hipHostFree
+#define cudaHostRegister                hipHostRegister
+#define cudaHostUnregister              hipHostUnregister
+#define cudaMemset                      hipMemset
+#define cudaMemsetAsync                 hipMemsetAsync
+#define cudaMemcpy                      hipMemcpy
+#define cudaMemcpyAsync                 hipMemcpyAsync
+#define cudaMemcpyToSymbol              hipMemcpyToSymbol
+#define cudaMemcpyToSymbolAsync         hipMemcpyToSymbolAsync
+
+/* hipMalloc3DArray requires the flags argument that cudaMalloc3DArray
+ * defaults to 0. */
+#define cudaMalloc3DArray(arr, desc, ext) hipMalloc3DArray((arr), (desc), (ext), 0)
+#define cudaFreeArray                   hipFreeArray
+#define cudaMemcpy3D                    hipMemcpy3D
+#define cudaMemcpy3DAsync               hipMemcpy3DAsync
+#define cudaCreateChannelDesc           hipCreateChannelDesc
+#define cudaCreateTextureObject         hipCreateTextureObject
+#define cudaDestroyTextureObject        hipDestroyTextureObject
+
+#define make_cudaExtent                 make_hipExtent
+#define make_cudaPitchedPtr             make_hipPitchedPtr
+#define make_cudaPos                    make_hipPos
+
+#define cudaStreamCreate                hipStreamCreate
+#define cudaStreamDestroy               hipStreamDestroy
+#define cudaStreamSynchronize           hipStreamSynchronize
+#define cudaStreamCreateWithFlags       hipStreamCreateWithFlags
+#define cudaStreamNonBlocking           hipStreamNonBlocking
+
+#define cudaEventCreate                 hipEventCreate
+#define cudaEventDestroy                hipEventDestroy
+#define cudaEventRecord                 hipEventRecord
+#define cudaEventSynchronize            hipEventSynchronize
+#define cudaEventElapsedTime            hipEventElapsedTime
+
+/* HIP provides the round-to-nearest single-precision intrinsics but not the
+ * round-toward-negative-infinity (_rd) variants. The reconstruction is
+ * iterative and graded by nRMSE/adjointness tolerances, not bit-exact output,
+ * so the 1-ULP rounding-mode difference is immaterial here. */
+#define __fsqrt_rd                      __fsqrt_rn
+#define __frcp_rd                       __frcp_rn
+
+/* ---- cuRAND -> hipRAND ---- */
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__HIPCC__)
+#include <hiprand/hiprand_kernel.h>
+#endif
+#define curandState                     hiprandState
+#define curandState_t                   hiprandState_t
+#define curand_init                     hiprand_init
+#define curand_uniform                  hiprand_uniform
+#define curand_normal                   hiprand_normal
+#define curand_poisson                  hiprand_poisson
+
+/*
+ * Runtime verdict for fp32 hardware linear texture filtering (defined in
+ * gpuUtils.cu). Cached and logged once per process.
+ */
+bool tigre_hw_linear_supported();
+
+/*
+ * Per-TU device flag mirroring the verdict, and the host helper that loads it.
+ * Both are header-local (static), so each translation unit binds to its own
+ * copy and no -fgpu-rdc is required: tex3D_TIGRE reads the flag in the same TU
+ * whose host code called tigre_sync_hw_linear() after creating the texture.
+ * Only emitted when a .cu is compiled by hipcc; plain-C++ TUs that include this
+ * shim (e.g. GpuIds.cpp) never touch the texture path.
+ */
+#if defined(__HIPCC__)
+static __constant__ int tigre_hw_linear_filter = 0;
+
+/*
+ * These are host helpers (called only from host code), but they must stay
+ * declared in the device-compilation pass too: HIP single-source parses the
+ * whole TU in both passes, so a host call site has to resolve the name even
+ * though the host body is codegen'd only in the host pass.
+ *
+ * tex3D_TIGRE forwards to a single hardware tex3D<float> fetch when the flag is
+ * set, and does the software 8-tap lerp when it is clear. So the flag is set
+ * (1) for a Linear texture (hardware trilinear) AND for a deliberately Point
+ * texture that the caller wants point-sampled as-is (matching CUDA, whose
+ * tex3D_TIGRE is always the hardware fetch); it is cleared (0) only for the
+ * Point fallback texture that needs software trilinear.
+ */
+__host__ static inline void tigre_set_hw_linear(int v) {
+    hipMemcpyToSymbol(HIP_SYMBOL(tigre_hw_linear_filter), &v, sizeof(int));
+}
+__host__ static inline void tigre_sync_hw_linear() {
+    tigre_set_hw_linear(tigre_hw_linear_supported() ? 1 : 0);
+}
+#endif /* __HIPCC__ */
+
+#else /* CUDA */
+
+#include <cuda_runtime_api.h>
+#include <cuda.h>
+
+/* On CUDA hardware linear filtering is always used; no self-test, no flag. */
+static inline bool tigre_hw_linear_supported() { return true; }
+static inline void tigre_sync_hw_linear() {}
+static inline void tigre_set_hw_linear(int) {}
+
+#endif /* USE_HIP */
+
+/*
+ * tex3D_TIGRE: replacement for the interpolated tex3D<float> reads.
+ *
+ * CUDA: forward to the hardware trilinear filter (the texture is created
+ * cudaFilterModeLinear). HIP: when tigre_hw_linear_filter is set (the runtime
+ * self-test confirmed hardware linear works and the texture was created
+ * cudaFilterModeLinear) forward to the hardware fetch as well; otherwise the
+ * texture is cudaFilterModePoint and we trilinearly interpolate in software.
+ * CUDA's unnormalized texture
+ * coordinate c samples between texels floor(c-0.5) and floor(c-0.5)+1 with
+ * weight frac(c-0.5); a point sample of texel i is read at coordinate i+0.5.
+ * Out-of-array neighbours read 0 through cudaAddressModeBorder, matching the
+ * hardware filter's border behaviour.
+ */
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__device__ __forceinline__ float tex3D_TIGRE(cudaTextureObject_t tex, float x, float y, float z)
+{
+#if defined(USE_HIP)
+    if (tigre_hw_linear_filter)
+        return tex3D<float>(tex, x, y, z);
+
+    const float xb = x - 0.5f, yb = y - 0.5f, zb = z - 0.5f;
+    const float fx = floorf(xb), fy = floorf(yb), fz = floorf(zb);
+    const float dx = xb - fx,   dy = yb - fy,   dz = zb - fz;
+
+    const float c000 = tex3D<float>(tex, fx + 0.5f,        fy + 0.5f,        fz + 0.5f);
+    const float c100 = tex3D<float>(tex, fx + 1.5f,        fy + 0.5f,        fz + 0.5f);
+    const float c010 = tex3D<float>(tex, fx + 0.5f,        fy + 1.5f,        fz + 0.5f);
+    const float c110 = tex3D<float>(tex, fx + 1.5f,        fy + 1.5f,        fz + 0.5f);
+    const float c001 = tex3D<float>(tex, fx + 0.5f,        fy + 0.5f,        fz + 1.5f);
+    const float c101 = tex3D<float>(tex, fx + 1.5f,        fy + 0.5f,        fz + 1.5f);
+    const float c011 = tex3D<float>(tex, fx + 0.5f,        fy + 1.5f,        fz + 1.5f);
+    const float c111 = tex3D<float>(tex, fx + 1.5f,        fy + 1.5f,        fz + 1.5f);
+
+    const float c00 = c000 * (1.0f - dx) + c100 * dx;
+    const float c10 = c010 * (1.0f - dx) + c110 * dx;
+    const float c01 = c001 * (1.0f - dx) + c101 * dx;
+    const float c11 = c011 * (1.0f - dx) + c111 * dx;
+
+    const float c0 = c00 * (1.0f - dy) + c10 * dy;
+    const float c1 = c01 * (1.0f - dy) + c11 * dy;
+
+    return c0 * (1.0f - dz) + c1 * dz;
+#else
+    return tex3D<float>(tex, x, y, z);
+#endif
+}
+#endif
+
+#endif /* CUDA_TO_HIP_H */

--- a/Common/CUDA/gpuUtils.cu
+++ b/Common/CUDA/gpuUtils.cu
@@ -1,9 +1,121 @@
 
+#include "cuda_to_hip.h"
 #include "gpuUtils.hpp"
-#include <cuda_runtime_api.h>
-#include <cuda.h>
 #include <string.h>
 #include <stdio.h>
+
+#if defined(USE_HIP) && (defined(__CUDACC__) || defined(__HIPCC__))
+/*
+ * Verified self-test for fp32 element-read hardware linear texture filtering.
+ *
+ * Some ROCm/hardware combinations reject creation of a cudaFilterModeLinear
+ * texture over an element-read float array outright; others accept it but
+ * silently point-sample, which would ship wrong results. So we do not trust
+ * creation success alone: we build a tiny 4x1x1 ramp texture (texel x has
+ * value x), create it Linear, then sample at x=2.0 (texel centre 1.5..2.5).
+ * Hardware linear returns 1.5; point sampling returns 2.0. The result is
+ * cached for the process and the verdict is logged once to stderr.
+ */
+__global__ static void tigre_hw_linear_probe(cudaTextureObject_t tex, float* out) {
+    /* x=2.0 is the midpoint between texel centres 1.5 (value 1) and 2.5 (value
+     * 2): hardware linear returns 1.5, point sampling returns 2.0. y,z sit on
+     * interior texel centres so border addressing does not pollute the lerp. */
+    *out = tex3D<float>(tex, 2.0f, 2.5f, 2.5f);
+}
+
+static bool tigre_run_hw_linear_test() {
+    /* Mirror the real projection/backprojection textures: a true 3D array with
+     * cudaAddressModeBorder and cudaReadModeElementType, created Linear. Some
+     * ROCm/hardware combinations accept a 1D Linear texture but reject this 3D
+     * border-addressed one, so the probe must match the real configuration. */
+    const int nx = 4, ny = 4, nz = 4;
+    float ramp[nz * ny * nx];
+    for (int z = 0; z < nz; ++z)
+        for (int y = 0; y < ny; ++y)
+            for (int x = 0; x < nx; ++x)
+                ramp[(z * ny + y) * nx + x] = (float)x;
+
+    cudaChannelFormatDesc ch = cudaCreateChannelDesc<float>();
+    cudaArray_t arr = 0;
+    cudaExtent ext = make_cudaExtent(nx, ny, nz);
+    if (cudaMalloc3DArray(&arr, &ch, ext) != cudaSuccess) {
+        cudaGetLastError();
+        return false;
+    }
+
+    cudaMemcpy3DParms cp = {0};
+    cp.srcPtr = make_cudaPitchedPtr((void*)ramp, nx * sizeof(float), nx, ny);
+    cp.dstArray = arr;
+    cp.extent = ext;
+    cp.kind = cudaMemcpyHostToDevice;
+    if (cudaMemcpy3D(&cp) != cudaSuccess) {
+        cudaGetLastError();
+        cudaFreeArray(arr);
+        return false;
+    }
+
+    cudaResourceDesc res;
+    memset(&res, 0, sizeof(res));
+    res.resType = cudaResourceTypeArray;
+    res.res.array.array = arr;
+
+    cudaTextureDesc td;
+    memset(&td, 0, sizeof(td));
+    td.normalizedCoords = false;
+    td.filterMode = cudaFilterModeLinear;
+    td.addressMode[0] = cudaAddressModeBorder;
+    td.addressMode[1] = cudaAddressModeBorder;
+    td.addressMode[2] = cudaAddressModeBorder;
+    td.readMode = cudaReadModeElementType;
+
+    cudaTextureObject_t tex = 0;
+    if (cudaCreateTextureObject(&tex, &res, &td, NULL) != cudaSuccess) {
+        cudaGetLastError();
+        cudaFreeArray(arr);
+        return false;
+    }
+
+    float* dout = 0;
+    if (cudaMalloc(&dout, sizeof(float)) != cudaSuccess) {
+        cudaGetLastError();
+        cudaDestroyTextureObject(tex);
+        cudaFreeArray(arr);
+        return false;
+    }
+
+    tigre_hw_linear_probe<<<1, 1>>>(tex, dout);
+    bool ok = (cudaDeviceSynchronize() == cudaSuccess);
+    float v = 0.0f;
+    if (ok && cudaMemcpy(&v, dout, sizeof(float), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        ok = false;
+    }
+    cudaGetLastError();
+
+    cudaFree(dout);
+    cudaDestroyTextureObject(tex);
+    cudaFreeArray(arr);
+
+    return ok && (fabsf(v - 1.5f) < 0.05f);
+}
+
+bool tigre_hw_linear_supported() {
+    static int cached = -1;
+    if (cached < 0) {
+        bool ok = tigre_run_hw_linear_test();
+        char name[128];
+        int dev = 0;
+        cudaGetDevice(&dev);
+        GetGpuName(dev, name);
+        fprintf(stderr,
+                "TIGRE: fp32 hardware linear texture filtering on %s: %s\n",
+                name,
+                ok ? "supported (hardware trilinear)"
+                   : "unsupported (software trilinear fallback)");
+        cached = ok ? 1 : 0;
+    }
+    return cached != 0;
+}
+#endif
 
 int GetGpuIdArray(const char* kacGPUName, int* piDeviceIds, int iIdCountMax, char* pcMessage) {
     if (pcMessage) {

--- a/Common/CUDA/ray_interpolated_projection.cu
+++ b/Common/CUDA/ray_interpolated_projection.cu
@@ -53,8 +53,7 @@
 
 
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "ray_interpolated_projection.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -195,7 +194,10 @@ template<bool sphericalrotation>
         ty=vectY*i+source.y;
         tz=vectZ*i+source.z;
         
-        sum += tex3D<float>(tex, tx+0.5f, ty+0.5f, tz+0.5f); // this line is 94% of time.
+        if (geo.accuracy>1)
+            sum += tex3D<float>(tex, tx+0.5f, ty+0.5f, tz+0.5f); // point-filtered texture
+        else
+            sum += tex3D_TIGRE(tex, tx+0.5f, ty+0.5f, tz+0.5f); // this line is 94% of time.
     }
     
     float deltalength=sqrtf((vectX*geo.dVoxelX)*(vectX*geo.dVoxelX)+
@@ -591,7 +593,7 @@ void CreateTextureInterp(const GpuIds& gpuids,const float* imagedata,Geometry ge
             geo.accuracy=1;
         }
         else{
-            texDescr.filterMode = cudaFilterModeLinear;
+            texDescr.filterMode = tigre_hw_linear_supported() ? cudaFilterModeLinear : cudaFilterModePoint;
         }
         texDescr.addressMode[0] = cudaAddressModeBorder;
         texDescr.addressMode[1] = cudaAddressModeBorder;
@@ -599,6 +601,10 @@ void CreateTextureInterp(const GpuIds& gpuids,const float* imagedata,Geometry ge
         texDescr.readMode = cudaReadModeElementType;
         cudaCreateTextureObject(&texImage[dev], &texRes, &texDescr, NULL);
         cudaCheckErrors("Texture object creation fail");
+        // tex3D_TIGRE follows this verdict: hardware fetch when supported, else
+        // software trilinear. The accuracy>1 kernel path samples through the raw
+        // tex3D<float> (point) above and never consults the flag.
+        tigre_sync_hw_linear();
     }
 }
 

--- a/Common/CUDA/ray_interpolated_projection_parallel.cu
+++ b/Common/CUDA/ray_interpolated_projection_parallel.cu
@@ -50,8 +50,7 @@
 
 
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "ray_interpolated_projection_parallel.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -181,7 +180,7 @@ __global__ void kernelPixelDetector_parallel_interpolated( Geometry geo,
         ty=vectY*i+S.y;
         tz=vectZ*i+S.z;
         
-        sum += tex3D<float>(tex, tx+0.5f, ty+0.5f, tz+0.5f); // this line is 94% of time.
+        sum += tex3D_TIGRE(tex, tx+0.5f, ty+0.5f, tz+0.5f); // this line is 94% of time.
         
     }
     float deltalength=sqrtf((vectX*geo.dVoxelX)*(vectX*geo.dVoxelX)+
@@ -439,11 +438,12 @@ void CreateTextureParallelInterp(float* image,Geometry geo,cudaArray** d_cuArrTe
     cudaTextureDesc     texDescr;
     memset(&texDescr, 0, sizeof(cudaTextureDesc));
     texDescr.normalizedCoords = false;
-    texDescr.filterMode = cudaFilterModeLinear;
+    texDescr.filterMode = tigre_hw_linear_supported() ? cudaFilterModeLinear : cudaFilterModePoint;
     texDescr.addressMode[0] = cudaAddressModeBorder;
     texDescr.addressMode[1] = cudaAddressModeBorder;
     texDescr.addressMode[2] = cudaAddressModeBorder;
     texDescr.readMode = cudaReadModeElementType;
     cudaCreateTextureObject(&texImage[0], &texRes, &texDescr, NULL);
-    
-}
+    tigre_sync_hw_linear();
+
+}

--- a/Common/CUDA/tv_proximal.cu
+++ b/Common/CUDA/tv_proximal.cu
@@ -54,6 +54,7 @@
 #define MAX_BUFFER 60
 #define BLOCK_SIZE 10  // BLOCK_SIZE^3 must be smaller than MAXTREADS
 
+#include "cuda_to_hip.h"
 #include "tv_proximal.hpp"
 #define cudaCheckErrors(msg) \
 do { \
@@ -690,4 +691,4 @@ void cpy_from_host(float* device_array,float* host_array,
     }
     cudaStreamSynchronize(stream);
     cudaMemcpyAsync(device_array +offset_device, host_array +offset_host,  bytes_device*sizeof(float), cudaMemcpyHostToDevice,stream);
-}
+}

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -45,8 +45,7 @@
 
 #define  PI_2 1.57079632679489661923
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "voxel_backprojection.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -252,9 +251,9 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
             // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
             
 #if IS_FOR_MATLAB_TIGRE
-            voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f)*weight;
+            voxelColumn[colIdx]+=tex3D_TIGRE(tex, v, u ,indAlpha+0.5f)*weight;
 #else
-            voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f)*weight;
+            voxelColumn[colIdx]+=tex3D_TIGRE(tex, u, v ,indAlpha+0.5f)*weight;
 #endif
         }  // END iterating through column of voxels
         
@@ -704,12 +703,13 @@ void CreateTexture(const GpuIds& gpuids, float* projectiondata,Geometry geo,cuda
         cudaTextureDesc     texDescr;
         memset(&texDescr, 0, sizeof(cudaTextureDesc));
         texDescr.normalizedCoords = false;
-        texDescr.filterMode = cudaFilterModeLinear;
+        texDescr.filterMode = tigre_hw_linear_supported() ? cudaFilterModeLinear : cudaFilterModePoint;
         texDescr.addressMode[0] = cudaAddressModeBorder;
         texDescr.addressMode[1] = cudaAddressModeBorder;
         texDescr.addressMode[2] = cudaAddressModeBorder;
         texDescr.readMode = cudaReadModeElementType;
         cudaCreateTextureObject(&texImage[dev], &texRes, &texDescr, NULL);
+        tigre_sync_hw_linear();
     }
 }
 

--- a/Common/CUDA/voxel_backprojection2.cu
+++ b/Common/CUDA/voxel_backprojection2.cu
@@ -45,8 +45,7 @@
 
 #define  PI_2 1.57079632679489661923
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "voxel_backprojection2.hpp"
 #include "TIGRE_common.hpp"
 #include <math.h>
@@ -245,9 +244,9 @@ __global__ void kernelPixelBackprojection(const Geometry geo, float* image,const
             u=y+(float)geo.nDetecU*0.5f;
             v=z+(float)geo.nDetecV*0.5f;
 #if IS_FOR_MATLAB_TIGRE
-            float sample=tex3D<float>(tex, v, u ,indAlpha+0.5f);
+            float sample=tex3D_TIGRE(tex, v, u ,indAlpha+0.5f);
 #else
-            float sample=tex3D<float>(tex, u, v ,indAlpha+0.5f);
+            float sample=tex3D_TIGRE(tex, u, v ,indAlpha+0.5f);
 #endif
             float weight=0;
             //
@@ -689,12 +688,13 @@ void CreateTexture2(const GpuIds& gpuids, float* projectiondata,Geometry geo,cud
         cudaTextureDesc     texDescr;
         memset(&texDescr, 0, sizeof(cudaTextureDesc));
         texDescr.normalizedCoords = false;
-        texDescr.filterMode = cudaFilterModeLinear;
+        texDescr.filterMode = tigre_hw_linear_supported() ? cudaFilterModeLinear : cudaFilterModePoint;
         texDescr.addressMode[0] = cudaAddressModeBorder;
         texDescr.addressMode[1] = cudaAddressModeBorder;
         texDescr.addressMode[2] = cudaAddressModeBorder;
         texDescr.readMode = cudaReadModeElementType;
         cudaCreateTextureObject(&texImage[dev], &texRes, &texDescr, NULL);
+        tigre_sync_hw_linear();
     }
 }
 #ifndef BACKPROJECTION_HPP

--- a/Common/CUDA/voxel_backprojection_parallel.cu
+++ b/Common/CUDA/voxel_backprojection_parallel.cu
@@ -46,8 +46,7 @@
 
 #define  PI_2 1.57079632679489661923
 #include <algorithm>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
+#include "cuda_to_hip.h"
 #include "voxel_backprojection.hpp"
 #include "voxel_backprojection_parallel.hpp"
 
@@ -245,9 +244,9 @@ __global__ void kernelPixelBackprojection_parallel(const Geometry geo, float* im
             // Get Value in the computed (U,V) and multiply by the corresponding weight.
             // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
 #if IS_FOR_MATLAB_TIGRE
-            voxelColumn[colIdx]+=tex3D<float>(tex, v+0.5f, u+0.5f ,indAlpha+0.5f);
+            voxelColumn[colIdx]+=tex3D_TIGRE(tex, v+0.5f, u+0.5f ,indAlpha+0.5f);
 #else
-            voxelColumn[colIdx]+=tex3D<float>(tex, u+0.5f, v+0.5f ,indAlpha+0.5f);
+            voxelColumn[colIdx]+=tex3D_TIGRE(tex, u+0.5f, v+0.5f ,indAlpha+0.5f);
 #endif
             
         }  // END iterating through column of voxels
@@ -616,12 +615,13 @@ void CreateTextureParallel(float* projectiondata,Geometry geo,cudaArray** d_cuAr
         cudaTextureDesc     texDescr;
         memset(&texDescr, 0, sizeof(cudaTextureDesc));
         texDescr.normalizedCoords = false;
-        texDescr.filterMode = cudaFilterModeLinear;
+        texDescr.filterMode = tigre_hw_linear_supported() ? cudaFilterModeLinear : cudaFilterModePoint;
         texDescr.addressMode[0] = cudaAddressModeBorder;
         texDescr.addressMode[1] = cudaAddressModeBorder;
         texDescr.addressMode[2] = cudaAddressModeBorder;
         texDescr.readMode = cudaReadModeElementType;
         cudaCreateTextureObject(&texImage[0], &texRes, &texDescr, NULL);
         cudaCheckErrors("Texture object creation fail");
+        tigre_sync_hw_linear();
     
-}
+}

--- a/Frontispiece/python_installation.md
+++ b/Frontispiece/python_installation.md
@@ -10,6 +10,7 @@
    - [Requirements](#requirements-1)
    - [Build Instructions](#build-instructions-1)
    - [Conda package](#conda-install-1)
+- [AMD GPU (ROCm/HIP)](#amd-gpu-rocmhip)
 - [Optional Code Style Enforcement](#optional-code-style-enforcement)
 - [Advanced](#advanced)
 
@@ -161,6 +162,44 @@ An unofficial conda package is built & maintained by CCPi Tomographic Imaging - 
 `conda install -c ccpi tigre`
 
 Please report conda issues [upstream](https://github.com/TomographicImaging/TIGRE-conda/issues).
+
+## AMD GPU (ROCm/HIP)
+
+TIGRE's Python backend can be built for AMD GPUs with ROCm instead of CUDA. The same `.cu` sources are compiled with `hipcc`, so the CUDA build is unchanged and is selected by default; the ROCm build is opt-in through environment variables.
+
+### Requirements
+
+1. Python 3
+2. AMD ROCm-capable GPU
+3. [ROCm](https://rocm.docs.amd.com/) (for building; includes `hipcc` and the HIP runtime)
+
+Tested on:
+
+| Software      | Version       |
+| ------------- |:-------------:|
+|**ROCm**| >=7.2 |
+|**Linux GPU**| gfx90a (Instinct MI250X) |
+|**Windows GPU**| gfx1201 (RDNA4) |
+
+### Build Instructions
+
+Set `BUILD_WITH_HIP=1` and the environment variables below, then build with `pip` as for the CUDA install:
+
+```sh
+export BUILD_WITH_HIP=1
+export ROCM_PATH=/opt/rocm
+export HIP_ARCH=gfx90a
+cd TIGRE/
+pip install . --no-build-isolation
+```
+
+- `BUILD_WITH_HIP=1` selects the ROCm/HIP build path.
+- `ROCM_PATH` points to the ROCm install (default `/opt/rocm`).
+- `HIP_ARCH` is the target GPU architecture for `--offload-arch`. Pass a comma-separated list to build for several, for example `HIP_ARCH=gfx90a,gfx1100,gfx1201`.
+
+**NOTE:** On Windows, also set `HIPCC` to the ROCm `clang++` (for example `%ROCM_PATH%\lib\llvm\bin\clang++.exe`); the build links the HIP runtime (`amdhip64`) instead of `cudart`.
+
+A successful installation should be able to execute the script at `TIGRE/Python/example.py`, the same as for the CUDA build.
 
 ## Optional Code Style Enforcement
 Optional linting dependencies are provided to enforce the prevailing codestyle in the Python component of the TIGRE library.

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,22 @@ import numpy
 from setuptools import setup, find_packages, Extension
 
 
+# Build the GPU backend with HIP/ROCm instead of CUDA. Set BUILD_WITH_HIP=1.
+# ROCM_PATH locates the ROCm install (default /opt/rocm) and HIP_ARCH selects
+# the target GPU architecture(s) for --offload-arch (comma-separated, default
+# gfx90a). On this path the .cu sources are compiled with hipcc and the GPU
+# runtime is amdhip64; the CUDA path below is unchanged.
+BUILD_WITH_HIP = os.environ.get("BUILD_WITH_HIP", "0") not in ("0", "", "false", "False")
+
 # Macros for compilation
 define_macros=[("IS_FOR_PYTIGRE", None)]
+GPU_RUNTIME_LIB = "amdhip64" if BUILD_WITH_HIP else "cudart"
+if BUILD_WITH_HIP:
+    # The host .cpp TUs include the compat header and must select the hip path.
+    # __HIP_PLATFORM_AMD__ lets the host compiler parse <hip/hip_runtime_api.h>
+    # (hipcc sets it for the .cu sources automatically).
+    define_macros.append(("USE_HIP", None))
+    define_macros.append(("__HIP_PLATFORM_AMD__", None))
 no_pinned=False
 if len(sys.argv)>2:
     if "--no_pinned_memory" in sys.argv[2:] :
@@ -116,19 +130,45 @@ def _is_cuda_file(path):
     return os.path.splitext(path)[1] in [".cu", ".cuh"]
 
 
-CUDA, CUDA_VERSION = locate_cuda()
+def locate_rocm():
+    """Locate the ROCm install and the target GPU architecture(s) for HIP."""
+    rocm_home = os.environ.get("ROCM_PATH") or os.environ.get("HIP_PATH") or "/opt/rocm"
+    hip_arch = os.environ.get("HIP_ARCH") or os.environ.get("HCC_AMDGPU_TARGET") or "gfx90a"
+    include = pjoin(rocm_home, "include")
+    lib = pjoin(rocm_home, "lib")
+    if not os.path.isdir(include):
+        raise EnvironmentError(
+            f"ROCm include dir not found at {include}; set ROCM_PATH to the ROCm install."
+        )
+    return {
+        "home": rocm_home,
+        "include": include,
+        "lib64": lib,
+        "hipcc": os.environ.get("HIPCC", pjoin(rocm_home, "bin", "hipcc")),
+        "arch": hip_arch,
+    }
 
-cuda_version = 11.0
-try:
-    cuda_version = float(CUDA_VERSION)
-except ValueError:
-    cuda_list = re.findall(r'\d+', CUDA_VERSION)
-    cuda_version = float( str(cuda_list[0] + '.' + cuda_list[1]))
 
-# Insert CUDA CC arguments
-for item in get_cuda_cc(CUDA["home"]):
-    str_arg = f"-gencode=arch=compute_{item},code=sm_{item}"
-    COMPUTE_CAPABILITY_ARGS.insert(0, str_arg)
+if BUILD_WITH_HIP:
+    # Skip locate_cuda()/get_cuda_cc(): they shell out to nvcc, which is absent
+    # on a ROCm-only host.
+    CUDA = locate_rocm()
+    cuda_version = 0.0
+    HIP_OFFLOAD_ARGS = [f"--offload-arch={a}" for a in CUDA["arch"].split(",") if a]
+else:
+    CUDA, CUDA_VERSION = locate_cuda()
+
+    cuda_version = 11.0
+    try:
+        cuda_version = float(CUDA_VERSION)
+    except ValueError:
+        cuda_list = re.findall(r'\d+', CUDA_VERSION)
+        cuda_version = float( str(cuda_list[0] + '.' + cuda_list[1]))
+
+    # Insert CUDA CC arguments
+    for item in get_cuda_cc(CUDA["home"]):
+        str_arg = f"-gencode=arch=compute_{item},code=sm_{item}"
+        COMPUTE_CAPABILITY_ARGS.insert(0, str_arg)
 
 
 # Obtain the numpy include directory.  This logic works across numpy versions.
@@ -202,7 +242,19 @@ class BuildExtension(build_ext):
             cflags = copy.deepcopy(extra_postargs)
             try:
                 original_compiler = self.compiler.compiler_so
-                if _is_cuda_file(src):
+                if _is_cuda_file(src) and BUILD_WITH_HIP:
+                    hipcc = CUDA["hipcc"]
+                    if not isinstance(hipcc, list):
+                        hipcc = [hipcc]
+                    self.compiler.set_executable("compiler_so", hipcc)
+                    if isinstance(cflags, dict):
+                        cflags = cflags["nvcc"]
+                    cflags = (
+                        ["-x", "hip", "-fPIC", "-D", "USE_HIP"]
+                        + HIP_OFFLOAD_ARGS
+                        + cflags
+                    )
+                elif _is_cuda_file(src):
                     nvcc = _join_cuda_home("bin", "nvcc")
                     if not isinstance(nvcc, list):
                         nvcc = [nvcc]
@@ -257,7 +309,38 @@ class BuildExtension(build_ext):
                 if len(src_list) >= 1 and len(obj_list) >= 1:
                     src = src_list[0]
                     obj = obj_list[0]
-                    if _is_cuda_file(src):
+                    if _is_cuda_file(src) and BUILD_WITH_HIP:
+                        hipcc = CUDA["hipcc"]
+                        rocm_home = CUDA["home"]
+                        if isinstance(cflags, dict):
+                            cflags = cflags["nvcc"]
+                        elif not isinstance(cflags, list):
+                            cflags = []
+
+                        hip_flags = (
+                            ["-x", "hip",
+                             "--hip-path=" + rocm_home,
+                             "-fms-runtime-lib=dll",
+                             "-D", "USE_HIP"]
+                            + HIP_OFFLOAD_ARGS
+                        )
+                        for macro in macros:
+                            if len(macro) == 2:
+                                if macro[1] is None:
+                                    hip_flags += ["-D", macro[0]]
+                                else:
+                                    hip_flags += ["-D", "{}={}".format(macro[0], macro[1])]
+                            elif len(macro) == 1:
+                                hip_flags += ["-U", macro[0]]
+
+                        # Filter out MSVC/Windows-SDK include paths (contain spaces
+                        # and are handled by clang's own Windows target sysroot).
+                        # Keep only project and ROCm include dirs.
+                        hip_inc = [p for p in include_list
+                                   if " " not in p]
+                        # Language flag must precede the source file.
+                        cmd = [hipcc] + hip_flags + ["-c", src, "-o", obj] + hip_inc
+                    elif _is_cuda_file(src):
                         nvcc = _join_cuda_home("bin", "nvcc")
                         if isinstance(cflags, dict):
                             cflags = cflags["nvcc"]
@@ -355,13 +438,14 @@ Ax_ext = Extension(
             "Common/CUDA/ray_interpolated_projection.cu",
             "Common/CUDA/ray_interpolated_projection_parallel.cu",
             "Common/CUDA/GpuIds.cpp",
+            "Common/CUDA/gpuUtils.cu",
             "Python/tigre/utilities/cuda_interface/_Ax.pyx",
         ],
         sdist=sys.argv[1] == "sdist",
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -384,7 +468,7 @@ Atb_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -405,7 +489,7 @@ tv_proximal_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -426,7 +510,7 @@ minTV_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -446,7 +530,7 @@ minPICCS_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -466,7 +550,7 @@ AwminTV_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -483,7 +567,7 @@ gpuUtils_ext = Extension(
         sdist=sys.argv[1] == "sdist",
     ),
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],
@@ -504,7 +588,7 @@ RandomNumberGenerator_ext = Extension(
     ),
     define_macros=define_macros,
     library_dirs=[CUDA["lib64"]],
-    libraries=["cudart"],
+    libraries=[GPU_RUNTIME_LIB],
     language="c++",
     runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
     include_dirs=[NUMPY_INCLUDE, CUDA["include"], "Common/CUDA/"],


### PR DESCRIPTION
This adds an AMD GPU build of TIGRE's Python backend with ROCm/HIP, alongside the existing CUDA build. The CUDA path is selected by default and the AMD support is added behind USE_HIP / BUILD_WITH_HIP, so every effort has been made to leave the CUDA build untouched; the ROCm build is opt-in through environment variables. The CUDA sources were compile-checked with nvcc but were not run, as the development hosts have no NVIDIA GPU.

How to review: setup.py first (the build wiring), then Common/CUDA/cuda_to_hip.h (the CUDA->HIP symbol mapping and the texture path), then the per-source changes (texture filter mode, the Siddon ray-loop bound, and the cuRAND -> hipRAND include), then the install-doc update.

setup.py keeps the existing hand-rolled per-.cu compiler driver and adds a BUILD_WITH_HIP branch (both the Unix and the MSVC/Windows paths). With BUILD_WITH_HIP=1 it compiles the .cu sources with hipcc (-x hip --offload-arch=$HIP_ARCH, default gfx90a; comma-separated for multiple targets), links amdhip64 instead of cudart, and skips the nvcc-at-import probing that is absent on a ROCm-only host. On Windows it drives clang++ directly with --hip-path and -fms-runtime-lib=dll to match the MSVC /MD CRT.

The main porting concern is the texture path. The backprojection kernels and the interpolated forward projector sample a 3D float array with trilinear filtering (cudaFilterModeLinear + cudaReadModeElementType). Whether AMD hardware can do that fetch is architecture-dependent: gfx90a (CDNA2) rejects creation of such a texture, while RDNA (gfx1100, gfx1201) accepts it and filters in hardware. Rather than hard-code one path, cuda_to_hip.h decides at runtime: a one-time self-test creates the real texture configuration over a small ramp and confirms a known sample actually interpolates -- not merely that creation succeeded, since some hardware accepts the texture but silently point-samples, which would ship wrong results. When supported, the texture is created Linear and tex3D_TIGRE forwards to the hardware fetch; otherwise it is created Point and tex3D_TIGRE interpolates in software, point-sampling the eight neighbours and lerping with CUDA's unnormalized -0.5 texel-center convention (out-of-array neighbours read 0, matching cudaAddressModeBorder). The texture's creation mode and the sampling path are driven from the single cached verdict so they cannot disagree. On CUDA the runtime helper reports supported without testing and the AMD-only code is excluded by the preprocessor, so the original hardware-filtered textures are used.

A separate robustness fix bounds the Siddon ray-marching loop. The loop length Np is computed from index bounds chosen by exact float-equality tests on quantities formed with __fdividef, an approximate division whose result can differ slightly between back ends; a flipped equality test could select an out-of-range bound and make Np astronomical (a data-dependent hang). A straight ray crosses at most Nx+Ny+Nz voxel-boundary planes, so Np is now capped at that geometric maximum. This cap is the one change on a shared code path; it is a no-op for every valid ray and on CUDA.

RandomNumberGenerator.cu uses device-side cuRAND, mapped to hipRAND in the compat header; the directed-rounding intrinsics __fsqrt_rd / __frcp_rd (absent in HIP) map to the round-to-nearest variants, immaterial for an nRMSE/adjointness-graded reconstruction.

This work was authored with the assistance of Claude, an AI assistant by Anthropic.

Test Plan:

Linux, gfx90a (AMD Instinct MI250X), ROCm 7.2.1 -- software trilinear fallback (hardware linear fp32 textures rejected on CDNA2):

    export BUILD_WITH_HIP=1 ROCM_PATH=/opt/rocm HIP_ARCH=gfx90a
    pip install -e . --no-build-isolation

Linux, gfx1100 (RDNA3), ROCm 7.2.1, and Windows 11, gfx1201 (RDNA4), ROCm 7.14 -- hardware linear texture filtering (the self-test reports supported and the hardware fetch is used). Windows drives clang++ directly:

    BUILD_WITH_HIP=1 HIPCC=<rocm>/lib/llvm/bin/clang++.exe ROCM_PATH=<rocm> HIP_ARCH=gfx1201
    pip install -e . --no-build-isolation

On the 256^3 head phantom (cone geometry): forward project (Siddon and interpolated), back project (matched and FDK), reconstruct with FDK and OS-SART; all outputs finite. Interpolated (trilinear) projection matches Siddon to within 0.5% relative norm; adjointness <Ax(x),y> ~= <x,Atb(y)> relative residual ~1.2e-05; sart/ossart/sirt/cgls/fista and the TV-regularized asd_pocs/awasd_pocs/os_asd_pocs solvers all produce finite reconstructions. Verified with both the software-fallback path (gfx90a) and the hardware-filtering path (gfx1100, gfx1201).

The CUDA build was compile-checked with nvcc (CUDA 13.3, IS_FOR_PYTIGRE, BUILD_WITH_HIP off) -- all changed sources compile; it was not linked or run, as no NVIDIA GPU was available. Other AMD architectures are buildable via HIP_ARCH but were not exercised here.

