### PR TITLE
Fix geometry numpy2 single angle

### DIFF
--- a/Python/tigre/utilities/geometry.py
+++ b/Python/tigre/utilities/geometry.py
@@ -22,6 +22,7 @@ class Geometry(object):
 
 
     def check_geo(self, angles, verbose=False):
+        angles = np.atleast_1d(np.asarray(angles))
         if angles.ndim == 1:
             self.n_proj = angles.shape[0]
             zeros_array = np.zeros((self.n_proj, 1), dtype=np.float32)
@@ -123,8 +124,9 @@ class Geometry(object):
 
         :return: None
         """
+        exclude_from_cast = ["nVoxel", "nDetector", "n_proj", "mode", "filter"]
         for attrib in self.__dict__:
-            if getattr(self, attrib) is not None:
+            if getattr(self, attrib) is not None and attrib not in exclude_from_cast:
                 try:
                     setattr(self, attrib, np.float32(getattr(self, attrib)))
                 except ValueError:

--- a/Python/tigre/utilities/geometry.py
+++ b/Python/tigre/utilities/geometry.py
@@ -152,7 +152,10 @@ class Geometry(object):
                     new_attrib = np.tile(old_attrib, (angles.shape[0], 1))
                     setattr(self, attrib, new_attrib)
                 elif old_attrib.shape in [(1,)]:
-                    new_attrib = np.tile(old_attrib, (angles.shape[0], 1))
+                    if attrib in ["DSD", "DSO", "COR"]:
+                        new_attrib = np.tile(old_attrib, angles.shape[0])
+                    else:
+                        new_attrib = np.tile(old_attrib, (angles.shape[0], 1))
                     setattr(self, attrib, new_attrib)
                 elif old_attrib.shape == (angles.shape[0],):
                     pass


### PR DESCRIPTION
## Summary
Fixes #744 

## Problem
When initializing a geometry with a single projection angle (where `angles.shape[0] == 1`), the `__check_and_repmat__` utility incorrectly tiles 1D scalar attributes (`COR`, `DSO`, `DSD`) into 2D arrays of shape `(1, 1)` instead of maintaining their intended 1D shape `(1,)`. 
In NumPy < 2.4, this triggered a deprecation warning. In NumPy >= 2.4, this raises a fatal `TypeError: only 0-dimensional arrays can be converted to Python scalars` when Cython attempts to parse the geometry.

## Solution
Added a conditional guard inside `__check_and_repmat__` to ensure that `COR`, `DSD`, and `DSO` parameters bypass the `(angles.shape[0], 1)` expansion when their original shape is `(1,)`. They are now correctly tiled as 1D arrays matching `angles.shape[0]`.

## Changes
- `Python/tigre/utilities/geometry.py`: Guarded scalar spatial attributes during geometry instantiation.
