### PR TITLE
fix: Resolve severe stripe artifacts in parallel beam projections by fixing intersection bypass bounds (Fixes #334)

### DIFF
--- a/Common/CUDA/Siddon_projection_parallel.cu
+++ b/Common/CUDA/Siddon_projection_parallel.cu
@@ -215,8 +215,8 @@ __global__ void kernelPixelDetector_parallel( Geometry geo,
     float ax,ay;
     ax=(source.x<pixel1D.x)?  (imin-source.x)/(ray.x+0.000000000001f)  :  (imax-source.x)/(ray.x+0.000000000001f);
     ay=(source.y<pixel1D.y)?  (jmin-source.y)/(ray.y+0.000000000001f)  :  (jmax-source.y)/(ray.y+0.000000000001f);
-    ay = (ray.y==0.0f)? -copysignf(1e11,ax) : ay;
-    ax = (ray.x==0.0f)? -copysignf(1e11,ay) : ax;
+    ay = (ray.y==0.0f)? 1e11f : ay;
+    ax = (ray.x==0.0f)? 1e11f : ax;
 //     az=(source.z<pixel1D.z)?  (kmin-source.z)/ray.z  :  (kmax-source.z)/ray.z;
     
     
@@ -334,9 +334,6 @@ int siddon_ray_projection_parallel(float* img, Geometry geo, float** result,floa
             geo.alpha=angles[proj_global*3];
             geo.theta=angles[proj_global*3+1];
             geo.psi  =angles[proj_global*3+2];
-            if(geo.alpha==0.0 || abs(geo.alpha-1.5707963267949)<0.0000001){
-                geo.alpha=geo.alpha+1.1920929e-07;
-            }
             
             //precomute distances for faster execution
             //Precompute per angle constant stuff for speed


### PR DESCRIPTION
### Summary
This PR addresses Issue #334, which reported severe stripe artifacts during parallel beam reconstruction (`OS_SART` / `Ax`) when modifying `DSD` and `DSO` parameters or projecting exactly at `0` or `90` degrees.

### Technical Details & Root Cause
The root cause of the stripes was found in `Common/CUDA/Siddon_projection_parallel.cu` in the Jacobs line intersection algorithm.

1. **The Bounding Bug (`-copysignf`)**:
When rays were perfectly parallel to the X or Y axes (`ray.x == 0.0f` or `ray.y == 0.0f`), the intersection bypass assignments used a flawed `-copysignf` operation:
`ay = (ray.y==0.0f)? -copysignf(1e11,ax) : ay;`
Because `ax` is positive, this resulted in `ay` evaluating to `-1e11`. Consequently, the starting intersection parameter (`aminc = min(ax, ay)`) plummeted to `-1e11`, placing the intersection logic radically out-of-bounds and yielding 0 projection values.

2. **The Hack Causing Stripes**:
To suppress this `-1e11` bug, a previous hack had added `1.1920929e-07` to `geo.alpha` when near 0 or $\pi/2$. This prevented division by exactly zero, but created an imperceptibly small slope. Depending on `DSD` and `DSO`, floating-point precision on this micro-slope caused the Y-plane grid tracker (`jmax`) to occasionally floor incorrectly across perfectly aligned source rays. This skipped entire Y-plane intersections, systematically corrupting ray sums and producing heavy stripe artifacts across the volume.

### Changes Made
- **Fixed Orthogonal Ray Bypass**: Replaced the flawed `-copysignf` logic with straightforward assignments to `1e11f` so parallel rays cleanly bypass intersecting bounding planes.
- **Removed the Angle Hack**: With the orthogonal ray handling natively stabilized, the floating-point `+1.1920929e-07` angle offset hack was safely removed, restoring true $0$ and $\pi/2$ angle projections.
