### PR TITLE
Fix duplicate 2π projections in Python examples

### DIFF
--- a/Python/demos/d03_generateData.py
+++ b/Python/demos/d03_generateData.py
@@ -30,7 +30,7 @@ geo = tigre.geometry_default(high_resolution=False)
 #%% Define angles of projection and load phantom image
 
 # define projection angles (in radians)
-angles = np.linspace(0, 2 * np.pi, 50)
+angles = np.linspace(0, 2 * np.pi, 50, endpoint=False)
 # load phantom image
 head = sample_loader.load_head_phantom(geo.nVoxel)
 

--- a/Python/demos/d04_SimpleReconstruction.py
+++ b/Python/demos/d04_SimpleReconstruction.py
@@ -32,7 +32,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d05_plottingFunctions.py
+++ b/Python/demos/d05_plottingFunctions.py
@@ -32,7 +32,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d06_Algorithms01.py
+++ b/Python/demos/d06_Algorithms01.py
@@ -30,7 +30,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 # %% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d07_Algorithms02.py
+++ b/Python/demos/d07_Algorithms02.py
@@ -30,7 +30,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d08_Algorithms03.py
+++ b/Python/demos/d08_Algorithms03.py
@@ -38,7 +38,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d09_Algorithms04.py
+++ b/Python/demos/d09_Algorithms04.py
@@ -53,7 +53,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d10_MeasureQuality.py
+++ b/Python/demos/d10_MeasureQuality.py
@@ -34,7 +34,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d11_PostProcessing.py
+++ b/Python/demos/d11_PostProcessing.py
@@ -34,7 +34,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d13_HelicalGeometry.py
+++ b/Python/demos/d13_HelicalGeometry.py
@@ -30,7 +30,7 @@ import time
 #%% Geometry
 geo = tigre.geometry_default(high_resolution=False)
 
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 angles = np.hstack([angles, angles, angles])  # loop 3 times
 
 # Load thorax phantom data

--- a/Python/demos/d14_Offsets.py
+++ b/Python/demos/d14_Offsets.py
@@ -44,7 +44,7 @@ geo.accuracy = 0.5
 
 ## Load data and generate projections
 # see previous demo for explanation
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
@@ -83,7 +83,7 @@ geo.offDetector = np.vstack(
     [10 * np.sin(angles), 10 * np.cos(angles)]
 ).T  # Offset of Detector            (mm)
 geo.offOrigin = np.vstack(
-    [40 * np.sin(angles), np.linspace(-30, 30, 100), 40 * np.cos(angles)]
+    [40 * np.sin(angles), np.linspace(-30, 30, len(angles)), 40 * np.cos(angles)]
 ).T  # Offset of image from origin   (mm)
 
 projections3 = tigre.Ax(head, geo, angles)

--- a/Python/demos/d15_3Dparallel.py
+++ b/Python/demos/d15_3Dparallel.py
@@ -37,7 +37,7 @@ geo = tigre.geometry(
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d16_2Dtomography.py
+++ b/Python/demos/d16_2Dtomography.py
@@ -60,7 +60,7 @@ geo.mode = "parallel"
 
 #%% Define angles of projection and load phantom image
 
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 head = sample_loader.load_head_phantom(geo.nVoxel)
 projections = tigre.Ax(head, geo, angles)
 tigre.plotSinogram(projections, 0)
@@ -102,7 +102,7 @@ geo.mode = "cone"
 
 #%% Define angles of projection and load phantom image
 
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 head = sample_loader.load_head_phantom(geo.nVoxel)
 projections = tigre.Ax(head, geo, angles)
 #%% reconstruct

--- a/Python/demos/d17_DetectorRotation.py
+++ b/Python/demos/d17_DetectorRotation.py
@@ -43,7 +43,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 
 roll = angles
 pitch = 0.7 * np.linspace(0, 1, len(angles))

--- a/Python/demos/d18_ArbitraryAxisOfRotation.py
+++ b/Python/demos/d18_ArbitraryAxisOfRotation.py
@@ -37,15 +37,13 @@ import tigre.algorithms as algs
 geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
-# define angles
-angles = np.linspace(0, 2 * np.pi, 100)
 ## Define angles
 numProjs = 100
 
 
-anglesY = np.linspace(0, 2 * np.pi, numProjs)
+anglesY = np.linspace(0, 2 * np.pi, numProjs, endpoint=False)
 anglesZ2 = anglesY
-anglesZ1 = np.pi * np.sin(np.linspace(0, 2 * np.pi, numProjs))
+anglesZ1 = np.pi * np.sin(anglesY)
 angles = np.vstack([anglesZ1, anglesY, anglesZ2]).T
 
 ## Get Image

--- a/Python/demos/d20_Algorithms05.py
+++ b/Python/demos/d20_Algorithms05.py
@@ -37,7 +37,7 @@ geo = tigre.geometry_default(high_resolution=False)
 
 #%% Load data and generate projections
 # define angles
-angles = np.linspace(0, 2 * np.pi, 100)
+angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 # generate projections

--- a/Python/demos/d25_Pytorch.py
+++ b/Python/demos/d25_Pytorch.py
@@ -139,7 +139,7 @@ dataset = torch.utils.data.Subset(dataset,  list(range(100)))
 
 # We are going to be reconstructing 28x28 images, so we need to define the geometry accordingly
 geo = tigre.geometry(mode="fan",nVoxel=[1,28,28]) # MNIST is 28x28
-angles = np.linspace(0, 2*np.pi, 50)
+angles = np.linspace(0, 2 * np.pi, 50, endpoint=False)
 
 # take one sample
 sample_image = dataset[0][0]

--- a/Python/tests/test_demo_angles.py
+++ b/Python/tests/test_demo_angles.py
@@ -1,0 +1,62 @@
+import ast
+import unittest
+from pathlib import Path
+
+DEMOS_DIR = Path(__file__).resolve().parents[1] / "demos"
+
+
+def _is_number(node, value):
+    return isinstance(node, ast.Constant) and node.value == value
+
+
+def _is_two_pi(node):
+    return (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Mult)
+        and _is_number(node.left, 2)
+        and isinstance(node.right, ast.Attribute)
+        and isinstance(node.right.value, ast.Name)
+        and node.right.value.id == "np"
+        and node.right.attr == "pi"
+    )
+
+
+class TestDemoAngles(unittest.TestCase):
+    def test_full_rotation_linspace_excludes_duplicate_endpoint(self):
+        violations = []
+
+        for demo_path in sorted(DEMOS_DIR.glob("*.py")):
+            source = demo_path.read_text(encoding="utf-8")
+            if "np.linspace" not in source:
+                continue
+            tree = ast.parse(source, filename=str(demo_path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or len(node.args) < 2:
+                    continue
+                if not (
+                    isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "np"
+                    and node.func.attr == "linspace"
+                    and _is_number(node.args[0], 0)
+                    and _is_two_pi(node.args[1])
+                ):
+                    continue
+
+                endpoint = next(
+                    (keyword.value for keyword in node.keywords if keyword.arg == "endpoint"),
+                    None,
+                )
+                if not (isinstance(endpoint, ast.Constant) and endpoint.value is False):
+                    violations.append(f"{demo_path.name}:{node.lineno}")
+
+        self.assertEqual(
+            violations,
+            [],
+            "Full-rotation demo angles must exclude the duplicate 2*pi endpoint: "
+            + ", ".join(violations),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python/tigre/algorithms/ista_algorithms.py
+++ b/Python/tigre/algorithms/ista_algorithms.py
@@ -82,7 +82,7 @@ class FISTA(IterativeReconAlg):
     >>> from tigre.demos.Test_data import data_loader
     >>> geo = tigre.geometry(mode='cone',default_geo=True,
     >>>                         nVoxel=np.array([512,512,512]))
-    >>> angles = np.linspace(0,2*np.pi,100)
+    >>> angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
     >>> src_img = data_loader.load_head_phantom(geo.nVoxel)
     >>> proj = tigre.Ax(src_img,geo,angles)
     >>> output = algs.fista(proj,geo,angles,niter=50

--- a/Python/tigre/algorithms/iterative_recon_alg.py
+++ b/Python/tigre/algorithms/iterative_recon_alg.py
@@ -101,7 +101,7 @@ class IterativeReconAlg(object):
     >>> from tigre.demos.Test_data import data_loader
     >>> geo = tigre.geometry(mode='cone',default_geo=True,
     >>>                         nVoxel=np.array([64,64,64]))
-    >>> angles = np.linspace(0,2*np.pi,100)
+    >>> angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
     >>> src_img = data_loader.load_head_phantom(geo.nVoxel)
     >>> proj = tigre.Ax(src_img,geo,angles)
     >>> output = algs.iterativereconalg(proj,geo,angles,niter=50
@@ -456,7 +456,7 @@ def decorator(IterativeReconAlg, name=None, docstring=None):  # noqa: N803
     >>> geo = tigre.geometry_default(high_resolution=False)
     >>> src = load_head_phantom(number_of_voxels=geo.nVoxel)
     >>> proj = Ax(src,geo,angles)
-    >>> angles = np.linspace(0,2*np.pi,100)
+    >>> angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
     >>> iterativereconalg = decorator(IterativeReconAlg)
     >>> output = iterativereconalg(proj,geo,angles, niter=50)
 

--- a/Python/tigre/algorithms/single_pass_algorithms.py
+++ b/Python/tigre/algorithms/single_pass_algorithms.py
@@ -46,7 +46,7 @@ def FDK(proj, geo, angles, **kwargs):
     >>> from tigre.demos.Test_data import data_loader
     >>> geo = tigre.geometry(mode='cone',default_geo=True,
     >>>                         nVoxel=np.array([64,64,64]))
-    >>> angles = np.linspace(0,2*np.pi,100)
+    >>> angles = np.linspace(0, 2 * np.pi, 100, endpoint=False)
     >>> src_img = data_loader.load_head_phantom(geo.nVoxel)
     >>> proj = tigre.Ax(src_img,geo,angles)
     >>> output = algs.FDK(proj,geo,angles)


### PR DESCRIPTION
## Summary

- generate full-rotation Python demo angles on the half-open interval [0, 2π)
- update copyable algorithm doc examples to use the same convention
- reuse the periodic angle grid in the arbitrary-axis demo and keep offset arrays tied to len(angles)
- add a CUDA-independent regression test that detects inclusive full-turn numpy.linspace calls in demos

## Why

numpy.linspace(0, 2 * numpy.pi, n) includes both endpoints by default. For a circular scan, 0 and 2π represent the same source view, so the examples generated one duplicate projection and showed a pattern that can cause angle/projection mismatches when copied for scanner data.

The change keeps n views while spacing them uniformly over [0, 2π). Limited-angle and half-turn examples are unchanged.

## Validation

- python -m unittest discover -s Python/tests -p test_demo_angles.py -v
- python -m py_compile on all changed Python files
- black --check --target-version py310 --fast Python/tests/test_demo_angles.py
- git diff --check

Fixes #754