### PR TITLE
docs(python): remove MATLAB doc() from geometry demo header

### DIFF
--- a/Python/demos/d01_CreateGeometry.py
+++ b/Python/demos/d01_CreateGeometry.py
@@ -1,9 +1,9 @@
 #%% DEMO 01: Describing your geometry
 #
-#  In TIGRE the geometry is stored in an structure. To see documentation
-#  about geometry, run:
-#
-#     doc('TIGRE/Geometry')
+#  In TIGRE the geometry is stored in a Geometry object (see
+#  tigre.utilities.geometry.Geometry / tigre.geometry()). The field list
+#  below documents the main parameters; this demo also constructs one
+#  step by step.
 #
 # --------------------------------------------------------------------------
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`Python/demos/d01_CreateGeometry.py` told users to run MATLAB’s `doc('TIGRE/Geometry')`. That has no place in a Python demo. The header now describes the Python `Geometry` object and points at the field documentation already in the file.

Fixes #755

## Test plan

- [x] Confirmed MATLAB `doc(...)` string removed from the Python demo
- [x] Header still introduces the geometry field list used later in the demo