### PR TITLE
Fix uncompressed XIM pixel array parsing

### DIFF
--- a/Python/tests/test_varian_xim.py
+++ b/Python/tests/test_varian_xim.py
@@ -1,0 +1,31 @@
+import importlib.util
+import struct
+from pathlib import Path
+
+import numpy as np
+
+XIM_PATH = Path(__file__).resolve().parents[1] / "tigre" / "utilities" / "io" / "varian" / "xim.py"
+
+
+def _load_xim():
+    spec = importlib.util.spec_from_file_location("xim", XIM_PATH)
+    xim = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(xim)
+    return xim.XIM
+
+
+def test_uncompressed_xim_exposes_pixel_array(tmp_path):
+    xim_path = tmp_path / "uncompressed.xim"
+    pixels = np.array([[-1, 0], [1, 1024]], dtype=np.int16)
+    xim_path.write_bytes(
+        b"XIMFILE\x00"
+        + struct.pack("<6i", 1, 2, 2, 16, 2, 0)
+        + struct.pack("<i", pixels.nbytes)
+        + pixels.tobytes()
+        + struct.pack("<2i", 0, 0)
+    )
+
+    image = _load_xim()(xim_path)
+
+    assert image.array.shape == (2, 2)
+    np.testing.assert_array_equal(image.array, pixels)

--- a/Python/tests/test_varian_xim.py
+++ b/Python/tests/test_varian_xim.py
@@ -16,10 +16,10 @@ def _load_xim():
 
 def test_uncompressed_xim_exposes_pixel_array(tmp_path):
     xim_path = tmp_path / "uncompressed.xim"
-    pixels = np.array([[-1, 0], [1, 1024]], dtype=np.int16)
+    pixels = np.array([[-1, 0], [1, 1024]], dtype="<i4")
     xim_path.write_bytes(
         b"XIMFILE\x00"
-        + struct.pack("<6i", 1, 2, 2, 16, 2, 0)
+        + struct.pack("<6i", 1, 2, 2, 32, 4, 0)
         + struct.pack("<i", pixels.nbytes)
         + pixels.tobytes()
         + struct.pack("<2i", 0, 0)

--- a/Python/tigre/utilities/io/varian/xim.py
+++ b/Python/tigre/utilities/io/varian/xim.py
@@ -113,13 +113,13 @@ class XIM:
                 self.pixel_buffer = xim.read(pixel_buffer_size)
                 if read_pixels:
                     if self.bytes_per_pixel == 1:
-                        dtype = np.int8
+                        dtype = "<i1"
                     elif self.bytes_per_pixel == 2:
-                        dtype = np.int16
+                        dtype = "<i2"
                     elif self.bytes_per_pixel == 4:
-                        dtype = np.int32
+                        dtype = "<i4"
                     elif self.bytes_per_pixel == 8:
-                        dtype = np.int64
+                        dtype = "<i8"
                     else:
                         raise ValueError(
                             "The XIM image has an unsupported bytes per pixel value. Raise a ticket on the pylinac Github with this file."

--- a/Python/tigre/utilities/io/varian/xim.py
+++ b/Python/tigre/utilities/io/varian/xim.py
@@ -110,7 +110,23 @@ class XIM:
             self.compression = decode_binary(xim, int)
             if not self.compression:
                 pixel_buffer_size = decode_binary(xim, int)
-                self.pixel_buffer = decode_binary(xim, str, num_values=pixel_buffer_size)
+                self.pixel_buffer = xim.read(pixel_buffer_size)
+                if read_pixels:
+                    if self.bytes_per_pixel == 1:
+                        dtype = np.int8
+                    elif self.bytes_per_pixel == 2:
+                        dtype = np.int16
+                    elif self.bytes_per_pixel == 4:
+                        dtype = np.int32
+                    elif self.bytes_per_pixel == 8:
+                        dtype = np.int64
+                    else:
+                        raise ValueError(
+                            "The XIM image has an unsupported bytes per pixel value. Raise a ticket on the pylinac Github with this file."
+                        )
+                    self.array = np.frombuffer(self.pixel_buffer, dtype=dtype).reshape(
+                        (self.img_height_px, self.img_width_px)
+                    )
             else:
                 lookup_table_size = decode_binary(xim, int)
                 self.lookup_table = np.fromfile(xim, count=lookup_table_size, dtype=np.uint8)


### PR DESCRIPTION
﻿﻿## Summary
- Decode uncompressed XIM pixel buffers into shaped signed-integer arrays.
- Add a synthetic 2×2 regression test.

## Testing
- `python -m pytest Python/tests/test_varian_xim.py -q`
- `python -m black --check Python/tests/test_varian_xim.py Python/tigre/utilities/io/varian/xim.py`
- `git diff --check`
