### PR TITLE
Release CUDA resources on error, and stop exit(1) in the Python binding

### DIFF
--- a/Common/CUDA/TIGRE_common.cpp
+++ b/Common/CUDA/TIGRE_common.cpp
@@ -1,8 +1,9 @@
-#if defined(IS_FOR_PYTIGRE)
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include "TIGRE_common.hpp"
+
+#if defined(IS_FOR_PYTIGRE)
 void mexPrintf(const char* format, ...) {
     PRINT_HERE("");
     va_list argpointer;
@@ -11,10 +12,40 @@ void mexPrintf(const char* format, ...) {
     va_end(argpointer);
 }
 void mexErrMsgIdAndTxt(const char* pcTag, const char* pcMsg) {
+    /* Record and return. This used to exit(1), which ended the host Python
+     * process on any CUDA error - no exception, no traceback, nothing the
+     * caller could catch. Callers now return the errors.hpp codes and the
+     * Cython layer raises TigreCudaCallError, so an error is something the
+     * caller can handle rather than the end of the interpreter. */
     PRINT_HERE("%s %s\n", pcTag, pcMsg);
-    exit(1);
+    tigreSetLastError(pcTag, pcMsg);
 }
 void mexWarnMsgIdAndTxt(const char* pcTag, const char* pcMsg) {
     PRINT_HERE("%s %s\n", pcTag, pcMsg);
 }
 #endif  // IS_FOR_PYTIGRE
+
+/* Detail of the last recorded error, shared by both bindings.
+ *
+ * One static buffer suffices: the CUDA entry points are called one at a time
+ * from the host language, and the binding reads the message immediately after
+ * a non-zero return. */
+static char s_lastError[512] = {0};
+
+void tigreSetLastError(const char* pcTag, const char* pcMsg) {
+    const char* tag = pcTag ? pcTag : "";
+    const char* msg = pcMsg ? pcMsg : "";
+#if defined(_MSC_VER)
+    _snprintf_s(s_lastError, sizeof(s_lastError), _TRUNCATE, "%s %s", tag, msg);
+#else
+    snprintf(s_lastError, sizeof(s_lastError), "%s %s", tag, msg);
+#endif
+}
+
+const char* tigreGetLastError(void) {
+    return s_lastError;
+}
+
+void tigreClearLastError(void) {
+    s_lastError[0] = '\0';
+}

--- a/Common/CUDA/TIGRE_common.hpp
+++ b/Common/CUDA/TIGRE_common.hpp
@@ -21,4 +21,27 @@ void mexWarnMsgIdAndTxt(const char* pcTag, const char* pcMsg);
 #include "mex.h"
 #include "tmwtypes.h"
 #endif  // IS_TIGRE_FOR_PYTHON
+
+/* Last error recorded by cudaCheckErrors(), so a binding can report WHAT
+ * failed rather than only that something did.
+ *
+ * Under IS_FOR_PYTIGRE, mexErrMsgIdAndTxt() used to exit(1): any CUDA error
+ * terminated the host Python process - no exception, no traceback, nothing the
+ * caller could catch, and the interpreter gone along with any unsaved work. A
+ * library must not end its host process. Under MATLAB the same call longjmps
+ * out of the middle of a CUDA function, running no cleanup, so every error
+ * leaked every device buffer, page-locked allocation, stream and texture held
+ * at that moment for the rest of the session.
+ *
+ * The CUDA entry points now return the codes from errors.hpp instead and clean
+ * up on the way out (see tigre_cleanup.hpp). Each binding reports at its own
+ * boundary: MATLAB raises a MATLAB error, and the Cython layer raises a
+ * TigreCudaCallError - the mechanism its error_list was always indexed against.
+ *
+ * Declared for both bindings so the CUDA sources stay binding-agnostic.
+ */
+void tigreSetLastError(const char* pcTag, const char* pcMsg);
+const char* tigreGetLastError(void);
+void tigreClearLastError(void);
+
 #endif  // _COMMON_HPP_20201017_

--- a/Common/CUDA/tigre_cleanup.hpp
+++ b/Common/CUDA/tigre_cleanup.hpp
@@ -1,0 +1,101 @@
+/*-------------------------------------------------------------------------
+ *
+ * Scope-based cleanup for the CUDA code.
+ *
+ * WHY THIS EXISTS
+ *
+ * The CUDA functions acquire a lot of resources - device buffers, page-locked
+ * host memory, host registrations, streams, texture objects and plain mallocs -
+ * and release them in one block at the end of the function. That is correct
+ * only while nothing leaves the function early, which is exactly what error
+ * handling needs to do. Historically neither binding managed it:
+ *
+ *   - MATLAB: cudaCheckErrors() called mexErrMsgIdAndTxt(), which longjmps back
+ *     to MATLAB from the middle of the function. A longjmp runs no destructors
+ *     and no cleanup code, so every CUDA error leaked every resource held at
+ *     that moment, for the lifetime of the MATLAB session.
+ *   - Python: mexErrMsgIdAndTxt() called exit(1), terminating the host process.
+ *
+ * Registering a release action next to each acquisition makes an early
+ * `return ERR_CUDA` safe, so the error can be reported at the binding boundary
+ * (a MATLAB error, or a Python TigreCudaCallError) instead of unwinding through
+ * live resources or killing the process.
+ *
+ * Actions run in reverse order of registration, so resources are released in
+ * the opposite order to acquisition. Releases are best effort and never throw:
+ * during error handling the CUDA context may already be unusable, and a failure
+ * to free must not mask the original error.
+ *
+ * This header uses no CUDA features beyond the runtime API calls the callers
+ * already make, so it does not change which GPUs or CUDA versions are
+ * supported.
+ *
+ * ---------------------------------------------------------------------------
+ * This file is part of the TIGRE Toolbox
+ * License:  Open Source under BSD.
+ *           See the full license at
+ *           https://github.com/CERN/TIGRE/blob/master/LICENSE
+ * ---------------------------------------------------------------------------
+ */
+
+#ifndef TIGRE_CLEANUP_HPP
+#define TIGRE_CLEANUP_HPP
+
+#include <cuda_runtime_api.h>
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace tigre {
+
+/** Collects release actions and runs them when it goes out of scope. */
+class CleanupScope {
+public:
+    CleanupScope() {}
+    ~CleanupScope() { run(); }
+
+    /** Register a release action. Called in reverse order on scope exit. */
+    void add(std::function<void()> action) {
+        actions_.push_back(std::move(action));
+    }
+
+    /** Release everything now; safe to call more than once. */
+    void run() {
+        for (std::vector<std::function<void()> >::reverse_iterator it = actions_.rbegin();
+             it != actions_.rend(); ++it) {
+            // Best effort: a failing release during error handling must not
+            // prevent the remaining ones, nor replace the original error.
+            try {
+                (*it)();
+            } catch (...) {
+            }
+        }
+        actions_.clear();
+        // Discard any error raised BY the releases themselves.
+        //
+        // Cleaning up must not change the error state the next call observes.
+        // These run while unwinding a failure, so they routinely operate on
+        // half-built state - unregistering a buffer that never registered,
+        // freeing a pointer whose allocation failed - and each of those leaves
+        // an error pending. cudaGetLastError() is sticky-until-read, so the
+        // NEXT entry point's first check would read it and report a failure
+        // that belongs to the previous call, making the library appear broken
+        // from then on. The error being reported has already been captured by
+        // the caller, so dropping these is safe.
+        cudaGetLastError();
+    }
+
+    /** Abandon the registered actions (the caller has taken ownership). */
+    void dismiss() { actions_.clear(); }
+
+private:
+    CleanupScope(const CleanupScope&);
+    CleanupScope& operator=(const CleanupScope&);
+
+    std::vector<std::function<void()> > actions_;
+};
+
+}  // namespace tigre
+
+#endif  // TIGRE_CLEANUP_HPP

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -49,16 +49,43 @@
 #include <cuda.h>
 #include "voxel_backprojection.hpp"
 #include "TIGRE_common.hpp"
+#include "tigre_cleanup.hpp"
+#include "errors.hpp"
 #include <math.h>
+#include <string.h>
+#include <vector>
 #include "GpuIds.hpp"
 
 // https://stackoverflow.com/questions/16282136/is-there-a-cuda-equivalent-of-perror
+//
+// Reports the error, then RETURNS ERR_CUDA to the caller rather than unwinding
+// out of the enclosing function. Previously mexErrMsgIdAndTxt() left by the
+// side door - a longjmp back to MATLAB, or exit(1) under Python - from the
+// middle of a function holding device buffers, page-locked host memory, host
+// registrations, streams and texture objects, none of which were released.
+// Returning lets the tigre::CleanupScope in the caller free them on the way
+// out, and lets the binding turn the code into a MATLAB error or a Python
+// TigreCudaCallError.
+//
+// Only usable in functions returning int; the void helpers below use
+// cudaCheckErrorsVoid() and record the error for the caller to notice.
 #define cudaCheckErrors(msg) \
 do { \
         cudaError_t __err = cudaGetLastError(); \
         if (__err != cudaSuccess) { \
                 mexPrintf("%s \n",msg);\
                 mexErrMsgIdAndTxt("CBCT:CUDA:Atb",cudaGetErrorString(__err));\
+                return ERR_CUDA;\
+        } \
+} while (0)
+
+#define cudaCheckErrorsVoid(msg) \
+do { \
+        cudaError_t __err = cudaGetLastError(); \
+        if (__err != cudaSuccess) { \
+                mexPrintf("%s \n",msg);\
+                mexErrMsgIdAndTxt("CBCT:CUDA:Atb",cudaGetErrorString(__err));\
+                return;\
         } \
 } while (0)
     
@@ -295,11 +322,34 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
     // printf("voxel_backprojection(geo.nDetector = %d, %d)\n", geo.nDetecU, geo.nDetecV);
     // printf("geo.nVoxel    = %d, %d, %d\n", geo.nVoxelX, geo.nVoxelY, geo.nVoxelZ);
     
+    // Start from a clean error state. cudaGetLastError() reports the last error
+    // from ANY earlier CUDA call and clears it, so without this the first check
+    // below can report a failure that happened before we were even called -
+    // which makes one failure look like every subsequent call failing too.
+    cudaGetLastError();
+
+    // Declared BEFORE the cleanup scope on purpose. These four are filled in
+    // later (cudaMallocHost writes through them; two are allocated inside the
+    // loop), so their release actions must capture them by reference - and a
+    // reference is only good while the object is alive. Locals are destroyed in
+    // reverse order of declaration, so anything the scope refers to has to be
+    // declared before it, or the scope would outlive what it points at.
+    Point3D* projParamsArrayHost = 0;
+    float* projSinCosArrayHost = 0;
+    float** partial_projection = 0;
+    size_t* proj_split_size = 0;
+
+    // Releases every resource acquired below, in reverse order, on ANY return
+    // from this function - including the error returns from cudaCheckErrors().
+    // Without it those returns would leak whatever had been acquired so far.
+    tigre::CleanupScope cleanup;
+
     // Prepare for MultiGPU
     int deviceCount = gpuids.GetLength();
     cudaCheckErrors("Device query fail");
     if (deviceCount == 0) {
         mexErrMsgIdAndTxt("Atb:Voxel_backprojection:GPUselect","There are no available device(s) that support CUDA\n");
+        return ERR_NO_CAPABLE_DEVICES;
     }
 
     // CODE assumes
@@ -327,60 +377,109 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
 #endif
     // empirical testing shows that when the image split is smaller than 1 (also implies the image is not very big), the time to
     // pin the memory is greater than the lost time in Synchronously launching the memcpys. This is only worth it when the image is too big.
-#ifndef NO_PINNED_MEMORY    
+#ifndef NO_PINNED_MEMORY
     if (isHostRegisterSupported & (split_image>1 |deviceCount>1)){
         cudaHostRegister(result, (size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geo.nVoxelZ*(size_t)sizeof(float),cudaHostRegisterPortable);
+        cleanup.add([result]{ cudaHostUnregister(result); });
     }
-    if (isHostRegisterSupported ){ 
-        cudaHostRegister(projections, (size_t)geo.nDetecU*(size_t)geo.nDetecV*(size_t)nalpha*(size_t)sizeof(float),cudaHostRegisterPortable); 
-    } 
+    if (isHostRegisterSupported ){
+        cudaHostRegister(projections, (size_t)geo.nDetecU*(size_t)geo.nDetecV*(size_t)nalpha*(size_t)sizeof(float),cudaHostRegisterPortable);
+        // These are the CALLER'S buffers (a MATLAB array or a NumPy array).
+        // Leaving them page-locked outlives this call and can make a later,
+        // unrelated transfer fail, so the unregister must happen on every path.
+        cleanup.add([projections]{ cudaHostUnregister(projections); });
+    }
 #endif
     cudaCheckErrors("Error pinning memory");
     
     
     // Create the arrays for the geometry. The main difference is that geo.offZ has been tuned for the
     // image slices. The rest of the Geometry is the same
-    Geometry* geoArray=(Geometry*)malloc(split_image*deviceCount*sizeof(Geometry));
+    const unsigned int nGeoArray = split_image*deviceCount;
+    Geometry* geoArray=(Geometry*)malloc(nGeoArray*sizeof(Geometry));
+    // Zero it first: createGeoArray mallocs a per-split offOrigZ, and if we
+    // leave this function before that happens, freeGeoArray would free
+    // uninitialised pointers. free(NULL) is a no-op, garbage is not.
+    memset(geoArray, 0, nGeoArray*sizeof(Geometry));
+    // freeGeoArray releases the per-split offOrigZ AND geoArray itself.
+    cleanup.add([geoArray,nGeoArray]{ freeGeoArray(nGeoArray,geoArray); });
     createGeoArray(split_image*deviceCount,geo,geoArray,nalpha);
-    
+
+    // Device ids, copied so the release lambdas do not depend on the caller's
+    // GpuIds outliving them.
+    std::vector<int> devIds(deviceCount);
+    for (dev = 0; dev < deviceCount; dev++) devIds[dev] = gpuids[dev];
+
     // Now lest allocate all the image memory on the GPU, so we can use it later. If we have made our numbers correctly
     // in the previous section this should leave enough space for the textures.
     size_t num_bytes_img = (size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geoArray[0].nVoxelZ* sizeof(float);
     float** dimage=(float**)malloc(deviceCount*sizeof(float*));
+    memset(dimage, 0, deviceCount*sizeof(float*));
+    // Registered BEFORE the allocation loop, and freed per device, so a failure
+    // part-way through still releases the buffers already allocated on the
+    // earlier devices.
+    cleanup.add([dimage]{ free(dimage); });
+    cleanup.add([dimage,devIds]{
+        for (size_t d = 0; d < devIds.size(); d++){
+            if (dimage[d]) { cudaSetDevice(devIds[d]); cudaFree(dimage[d]); }
+        }
+    });
     for (dev = 0; dev < deviceCount; dev++){
         cudaSetDevice(gpuids[dev]);
         cudaMalloc((void**)&dimage[dev], num_bytes_img);
         cudaCheckErrors("cudaMalloc fail");
     }
-    
+
     //If it is the first time, lets make sure our image is zeroed.
     int nStreamDevice=2;
     int nStreams=deviceCount*nStreamDevice;
     cudaStream_t* stream=(cudaStream_t*)malloc(nStreams*sizeof(cudaStream_t));;
-    
+    memset(stream, 0, nStreams*sizeof(cudaStream_t));
+    cleanup.add([stream]{ free(stream); });
+    cleanup.add([stream,nStreams]{
+        for (int i = 0; i < nStreams; ++i) if (stream[i]) cudaStreamDestroy(stream[i]);
+    });
+
     for (dev = 0; dev < deviceCount; dev++){
         cudaSetDevice(gpuids[dev]);
         for (int i = 0; i < nStreamDevice; ++i){
             cudaStreamCreate(&stream[i+dev*nStreamDevice]);
-            
+
         }
     }
-    
+
 
      
     
-    // Kernel auxiliary variables
-    Point3D* projParamsArrayHost;
+    // Kernel auxiliary variables (declared above the cleanup scope)
     cudaMallocHost((void**)&projParamsArrayHost,6*PROJ_PER_KERNEL*sizeof(Point3D));
-    float* projSinCosArrayHost;
+    cleanup.add([&projParamsArrayHost]{ if (projParamsArrayHost) cudaFreeHost(projParamsArrayHost); });
     cudaMallocHost((void**)&projSinCosArrayHost,5*PROJ_PER_KERNEL*sizeof(float));
-    
-    
+    cleanup.add([&projSinCosArrayHost]{ if (projSinCosArrayHost) cudaFreeHost(projSinCosArrayHost); });
+
+
     // Texture object variables
     cudaTextureObject_t *texProj;
     cudaArray **d_cuArrTex;
     texProj =(cudaTextureObject_t*)malloc(deviceCount*2*sizeof(cudaTextureObject_t));
     d_cuArrTex =(cudaArray**)malloc(deviceCount*2*sizeof(cudaArray*));
+    memset(texProj, 0, deviceCount*2*sizeof(cudaTextureObject_t));
+    memset(d_cuArrTex, 0, deviceCount*2*sizeof(cudaArray*));
+    cleanup.add([texProj]{ free(texProj); });
+    cleanup.add([d_cuArrTex]{ free(d_cuArrTex); });
+    // Release any texture/array still live if we leave from inside the loop.
+    // The normal path destroys them at the end and zeroes the slots, so this
+    // is a no-op then; on an error return it is the only thing that frees them.
+    cleanup.add([texProj,d_cuArrTex,devIds]{
+        for (size_t d = 0; d < devIds.size(); d++){
+            cudaSetDevice(devIds[d]);
+            for (size_t i = 0; i < 2; i++){
+                size_t k = i*devIds.size()+d;
+                if (texProj[k])    cudaDestroyTextureObject(texProj[k]);
+                if (d_cuArrTex[k]) cudaFreeArray(d_cuArrTex[k]);
+            }
+        }
+    });
     
     // Auxiliary Host page-locked memory for fast and asycnornous memcpy.
 
@@ -393,8 +492,11 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
     unsigned int current_proj_split_size,current_proj_overlap_split_size;
     size_t num_bytes_img_curr;
     size_t img_linear_idx_start;
-    float** partial_projection;
-    size_t* proj_split_size;
+    // Allocated once inside the loop below (guarded by !proj && !img_slice).
+    // Declared above the cleanup scope; released by it, so an early return
+    // frees them whether or not the loop got far enough to allocate.
+    cleanup.add([&partial_projection]{ if (partial_projection) free(partial_projection); });
+    cleanup.add([&proj_split_size]{ if (proj_split_size) free(proj_split_size); });
     
     
     
@@ -575,47 +677,37 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
     } // end image splits
 
     ///////// Cleaning:
-    
-    
+    //
+    // The texture objects and their arrays are created inside the image-split
+    // loop, so they are released here rather than by the CleanupScope; the
+    // pointers are zeroed so the scope's own release is idempotent if we leave
+    // early. Everything else - device buffers, page-locked host memory, host
+    // registrations, streams and the plain mallocs - is released by `cleanup`
+    // when this function returns, by ANY path.
+
     bool two_buffers_used=((((nalpha+split_projections-1)/split_projections)+PROJ_PER_KERNEL-1)/PROJ_PER_KERNEL)>1;
     for(unsigned int i=0; i<2;i++){ // 2 buffers (if needed, maybe only 1)
         if (!two_buffers_used && i==1)
             break;
         for (dev = 0; dev < deviceCount; dev++){
             cudaSetDevice(gpuids[dev]);
-            cudaDestroyTextureObject(texProj[i*deviceCount+dev]);
-            cudaFreeArray(d_cuArrTex[i*deviceCount+dev]);
+            if (texProj[i*deviceCount+dev]) {
+                cudaDestroyTextureObject(texProj[i*deviceCount+dev]);
+                texProj[i*deviceCount+dev]=0;
+            }
+            if (d_cuArrTex[i*deviceCount+dev]) {
+                cudaFreeArray(d_cuArrTex[i*deviceCount+dev]);
+                d_cuArrTex[i*deviceCount+dev]=0;
+            }
         }
     }
     cudaCheckErrors("cudadestroy textures result fail");
-    
-    for (dev = 0; dev < deviceCount; dev++){
-        cudaSetDevice(gpuids[dev]);
-        cudaFree(dimage[dev]);
-    }
-    cudaFreeHost(projSinCosArrayHost);
-    cudaFreeHost(projParamsArrayHost);
-    free(partial_projection);
-    free(proj_split_size);
-    
-    freeGeoArray(split_image*deviceCount,geoArray);
-#ifndef NO_PINNED_MEMORY        
-    if (isHostRegisterSupported & (split_image>1 |deviceCount>1)){
-        cudaHostUnregister(result);
-    }
-    if (isHostRegisterSupported){
-        cudaHostUnregister(projections);
-    }
-#endif
-    
-    for (int i = 0; i < nStreams; ++i)
-        cudaStreamDestroy(stream[i]);
-    
+
     cudaCheckErrors("cudaFree fail");
-    
+
     //cudaDeviceReset(); // For the Nvidia Visual Profiler
-    return 0;
-    
+    return CUDA_SUCCESS;
+
 }  // END voxel_backprojection
 //
 
@@ -909,8 +1001,8 @@ void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){
         if(memfree<memtotal/2){
             mexErrMsgIdAndTxt("voxel_backprojection:Atb:GPU","One (or more) of your GPUs is being heavily used by another program (possibly graphics-based).\n Free the GPU to run TIGRE\n");
         }
-        cudaCheckErrors("Check mem error");
-        
+        cudaCheckErrorsVoid("Check mem error");
+
         *mem_GPU_global=(memfree<*mem_GPU_global)?memfree:*mem_GPU_global;
     }
     *mem_GPU_global=(size_t)((double)*mem_GPU_global*0.95);

--- a/MATLAB/Utilities/cuda_interface/Atb_mex.cpp
+++ b/MATLAB/Utilities/cuda_interface/Atb_mex.cpp
@@ -57,6 +57,8 @@
 #include <CUDA/voxel_backprojection2.hpp>
 #include <CUDA/voxel_backprojection_parallel.hpp>
 #include <CUDA/GpuIds.hpp>
+#include <CUDA/errors.hpp>
+#include <CUDA/TIGRE_common.hpp>
 
 
 
@@ -351,14 +353,27 @@ void mexFunction(int  nlhs , mxArray *plhs[],
     
    
     // Run the CUDA code.
+    //
+    // Report at THIS boundary, not from inside the CUDA code. The error used to
+    // be raised by mexErrMsgIdAndTxt() deep inside voxel_backprojection(),
+    // which longjmps straight back to MATLAB from the middle of a function
+    // holding device buffers, page-locked host memory, host registrations,
+    // streams and texture objects - running no cleanup, so a CUDA error leaked
+    // all of them for the rest of the session. The CUDA functions now release
+    // everything on the way out and return an errors.hpp code; we turn that
+    // into the MATLAB error here, after the cleanup has happened.
+    int tigre_status = CUDA_SUCCESS;
     if (coneBeam){
         if (pseudo_matched){
-            voxel_backprojection2(projections,geo,result,angles,nangles, gpuids);
+            tigre_status = voxel_backprojection2(projections,geo,result,angles,nangles, gpuids);
         }else{
-            voxel_backprojection(projections,geo,result,angles,nangles, gpuids);
+            tigre_status = voxel_backprojection(projections,geo,result,angles,nangles, gpuids);
         }
     }else{
-        voxel_backprojection_parallel(projections,geo,result,angles,nangles, gpuids);
+        tigre_status = voxel_backprojection_parallel(projections,geo,result,angles,nangles, gpuids);
+    }
+    if (tigre_status != CUDA_SUCCESS){
+        mexErrMsgIdAndTxt("CBCT:CUDA:Atb", tigreGetLastError());
     }
 
 

--- a/Python/tests/test_cuda_error_propagation.py
+++ b/Python/tests/test_cuda_error_propagation.py
@@ -1,0 +1,143 @@
+"""A CUDA error must be reportable and must not leak.
+
+Before this change a CUDA error inside voxel_backprojection() left through
+mexErrMsgIdAndTxt(), which under IS_FOR_PYTIGRE called exit(1): the interpreter
+was gone, so there was nothing to catch and no way to observe what had been
+left behind. Under MATLAB the same call longjmps out, running no cleanup at
+all. Either way the device buffers, page-locked host memory, host
+registrations, streams and texture objects held at that moment stayed
+allocated.
+
+These tests pin the four properties the fix is for:
+
+  1. the success path is unchanged;
+  2. repeated calls do not drift GPU memory;
+  3. a failure raises something catchable instead of ending the process;
+  4. the process still works afterwards.
+
+Free-memory readings come from the CUDA runtime via ctypes rather than a
+third-party package, so this adds no dependency: TIGRE already links the CUDA
+runtime, and its Python requirements are numpy/scipy/matplotlib/h5py/tqdm. If
+the library cannot be located the memory test reports skipped rather than
+failing for an unrelated reason.
+"""
+
+import ctypes
+import unittest
+
+import numpy as np
+
+import tigre
+from tigre.utilities.errors import TigreCudaCallError
+
+
+def _load_cudart():
+    """The already-linked CUDA runtime, or None if it cannot be located."""
+    names = [
+        # Linux
+        "libcudart.so", "libcudart.so.13", "libcudart.so.12", "libcudart.so.11.0",
+        # Windows
+        "cudart64_13.dll", "cudart64_12.dll", "cudart64_110.dll", "cudart64_101.dll",
+    ]
+    for name in names:
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    return None
+
+
+_CUDART = _load_cudart()
+
+
+def gpu_free_bytes():
+    """Free device memory, or None if the runtime is unavailable."""
+    if _CUDART is None:
+        return None
+    free, total = ctypes.c_size_t(0), ctypes.c_size_t(0)
+    if _CUDART.cudaMemGetInfo(ctypes.byref(free), ctypes.byref(total)) != 0:
+        return None
+    return free.value
+
+
+def make_geometry(nvoxel=128, ndetector=128):
+    geo = tigre.geometry(mode="cone", default=True, nVoxel=np.array([nvoxel] * 3))
+    geo.nDetector = np.array([ndetector, ndetector])
+    geo.dDetector = np.array([0.8, 0.8])
+    geo.sDetector = geo.nDetector * geo.dDetector
+    return geo
+
+
+class TestCudaErrorPropagation(unittest.TestCase):
+    def setUp(self):
+        self.geo = make_geometry()
+        self.angles = np.linspace(0, 2 * np.pi, 32, dtype=np.float32)
+        self.proj = np.ones(
+            (len(self.angles), self.geo.nDetector[0], self.geo.nDetector[1]),
+            dtype=np.float32)
+
+    def test_backprojection_still_works(self):
+        """The success path must be untouched by the error handling."""
+        vol = tigre.Atb(self.proj, self.geo, self.angles)
+        self.assertEqual(tuple(vol.shape), tuple(self.geo.nVoxel))
+        self.assertTrue(np.all(np.isfinite(vol)))
+        self.assertGreater(float(np.abs(vol).max()), 0.0)
+
+    def test_repeated_calls_do_not_leak(self):
+        """Each call page-locks the caller's projections and allocates device
+        memory, streams and textures. A steady decline in free memory means one
+        of those is not being handed back."""
+        if gpu_free_bytes() is None:
+            self.skipTest("CUDA runtime not loadable via ctypes")
+
+        tigre.Atb(self.proj, self.geo, self.angles)   # absorb one-off context setup
+        before = gpu_free_bytes()
+        for _ in range(5):
+            tigre.Atb(self.proj, self.geo, self.angles)
+        after = gpu_free_bytes()
+
+        drift_mb = (before - after) / 1e6
+        self.assertLess(abs(drift_mb), 50.0,
+                        "GPU memory drifted {:+.1f} MB over 5 calls".format(drift_mb))
+
+    def test_failure_raises_instead_of_exiting(self):
+        """Ask for a volume far larger than the card.
+
+        Reaching the assertion at all is part of the result: with exit(1) the
+        interpreter would have gone with the error."""
+        free = gpu_free_bytes()
+        if free is None:
+            self.skipTest("CUDA runtime not loadable via ctypes")
+
+        # Comfortably beyond the device, but still an expressible size.
+        n = int(((free * 8) / 4) ** (1.0 / 3.0))
+        geo = make_geometry(nvoxel=n, ndetector=256)
+        angles = np.linspace(0, 2 * np.pi, 16, dtype=np.float32)
+        proj = np.ones((len(angles), geo.nDetector[0], geo.nDetector[1]),
+                       dtype=np.float32)
+
+        with self.assertRaises((TigreCudaCallError, MemoryError)):
+            tigre.Atb(proj, geo, angles)
+
+    def test_usable_after_a_failure(self):
+        """A failed call should cost that call, not the session - and a
+        half-released state would show up here."""
+        free = gpu_free_bytes()
+        if free is not None:
+            n = int(((free * 8) / 4) ** (1.0 / 3.0))
+            geo = make_geometry(nvoxel=n, ndetector=256)
+            angles = np.linspace(0, 2 * np.pi, 16, dtype=np.float32)
+            proj = np.ones((len(angles), geo.nDetector[0], geo.nDetector[1]),
+                           dtype=np.float32)
+            try:
+                tigre.Atb(proj, geo, angles)
+            except Exception:                                     # noqa: BLE001
+                pass
+
+        vol = tigre.Atb(self.proj, self.geo, self.angles)
+        self.assertTrue(np.all(np.isfinite(vol)))
+        self.assertGreater(float(np.abs(vol).max()), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A CUDA error inside the backprojector currently leaves by the side door. cudaCheckErrors() calls mexErrMsgIdAndTxt() from the middle of voxel_backprojection(), and neither binding survives that well:

  * MATLAB: mexErrMsgIdAndTxt() longjmps back to MATLAB. A longjmp runs no cleanup, so the device buffers, page-locked host memory, host registrations, streams and texture objects held at that moment are all leaked - for the rest of the session, since the GPU context outlives the call.

  * Python: mexErrMsgIdAndTxt() calls exit(1) (Common/CUDA/TIGRE_common.cpp), terminating the host process. There is no exception to catch, no traceback, and the interpreter is gone along with any unsaved work. A library should not end its host process.

The mechanism to do this properly already exists but was never wired up: errors.hpp defines CUDA_SUCCESS/ERR_CUDA/..., voxel_backprojection() is declared to return int, and the Cython layer already calls cuda_raise_errors() on the result - TigreCudaCallError's error_list is documented as "indexed against values in errors.hpp". The function simply always returned 0.

This change:

  * adds Common/CUDA/tigre_cleanup.hpp, a small scope guard that runs registered release actions in reverse order on ANY return path;

  * registers a release action beside each acquisition in voxel_backprojection() - host registrations, device buffers (per device, so a failure part-way through still frees the earlier ones), streams, cudaMallocHost buffers, texture objects/arrays and the plain mallocs. The geometry array is zeroed before use so an early exit cannot free uninitialised pointers;

  * makes cudaCheckErrors() return ERR_CUDA after reporting, which is now safe; void helpers use cudaCheckErrorsVoid();

  * removes the exit(1) - the error text is recorded via tigreSetLastError() for the binding to report;

  * reports at each binding boundary instead: Atb_mex.cpp checks the returned status and raises the MATLAB error there, after cleanup has run, and the Cython layer's existing cuda_raise_errors() starts working because non-zero codes now actually flow;

  * keeps the CUDA error state per-call. cudaGetLastError() is sticky until read, so two things were needed to stop one failure making every later call look broken: clear stale state on entry, and discard errors raised by the cleanup itself (it necessarily runs on half-built state - unregistering a buffer that never registered, freeing an allocation that failed). Without this the next call reports the previous call's error at its first check. Found by the added test, not by inspection.

Behaviour is unchanged on the success path, and unchanged from a MATLAB user's point of view on the error path (same message, same failure) except that the resources are released first. No new CUDA APIs are used, so GPU and CUDA version support is unaffected, and the multi-GPU logic (GpuIds, device loops, splitting) is untouched.

Python/tests/test_cuda_error_propagation.py covers the four properties that matter: the success path still works, repeated calls do not drift GPU memory, a failure raises a catchable error instead of exiting, and the process is still usable afterwards. It reads free memory through ctypes against the CUDA runtime TIGRE already links, so it adds no dependency, and skips those checks if the runtime cannot be located.

Only voxel_backprojection() is converted here to keep the diff reviewable; the same pattern applies to the other entry points and can follow.

Tested on:

  Linux workstation, Ubuntu 22.04.5 (kernel 6.8), 2 x Ada-generation GPUs
  (sm_89, 48 GiB each, driver 580.173.02), CUDA 13.0 (V13.0.88), gcc 11.4.0,
  Python 3.12.13.

  Windows 11 workstation, 1 x Ampere-generation GPU (sm_86, 45 GiB, driver
  596.59, WDDM), CUDA 13.3 (V13.3.73), MSVC 14.44.35207, Python 3.12.12.

Both built clean (no new warnings) and passed all four tests in Python/tests/test_cuda_error_propagation.py. The pair covers two operating systems, two host compilers, two CUDA toolkits and two GPU architectures; the multi-GPU host matters in particular, because the per-device release loop only iterates more than once there.

Not exercised: the MATLAB binding. Atb_mex.cpp is changed to check the returned status and raise the MATLAB error at the boundary rather than from inside the CUDA code, but no MATLAB installation was available to run it, so that half is reviewed-by-inspection only.