### PR TITLE
Fix: POCS `lambda_red` never reaches the data step (ASD-POCS / PICCS / PCSD)

### DIFF
--- a/Python/tigre/algorithms/pocs_algorithms.py
+++ b/Python/tigre/algorithms/pocs_algorithms.py
@@ -108,6 +108,20 @@ class initASD_POCS(IterativeReconAlg):
         # kwargs.update(dict(regularization="minimizeTV"))
         # if "blocksize" not in kwargs:
         #     kwargs.update(dict(blocksize=1))
+        # MATLAB's ASD_POCS/OS_AwASD_POCS/PCSD default beta_red = 0.99, and `beta` there is
+        # the same quantity this port calls `lmbda`. IterativeReconAlg's shared default is
+        # lmbda_red = 1, which is right for the SART family (MATLAB SART/OS_SART/SIRT all
+        # default lambdared = 1) but wrong to inherit here. Set it before delegating so an
+        # explicit caller value still wins.
+        if "lmbda_red" not in kwargs:
+            kwargs.update(dict(lmbda_red=0.99))
+        # MATLAB's ASD_POCS/OS_AwASD_POCS/PCSD default beta_red = 0.99, and `beta` there is
+        # the same quantity this port calls `lmbda`. IterativeReconAlg's shared default is
+        # lmbda_red = 1, which is right for the SART family (MATLAB SART/OS_SART/SIRT all
+        # default lambdared = 1) but wrong to inherit here. Set it before delegating so an
+        # explicit caller value still wins.
+        if "lmbda_red" not in kwargs:
+            kwargs.update(dict(lmbda_red=0.99))
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)       
         self.alpha = 0.002 if "alpha" not in kwargs else kwargs["alpha"]
         self.alpha = np.asarray(self.alpha).item()
@@ -537,6 +551,13 @@ class initPCSD(IterativeReconAlg):
         # if "blocksize" not in kwargs:
         #     kwargs.update(dict(blocksize=1))
         #kwargs.update(dict(regularization="minimizeTV"))
+        # MATLAB's ASD_POCS/OS_AwASD_POCS/PCSD default beta_red = 0.99, and `beta` there is
+        # the same quantity this port calls `lmbda`. IterativeReconAlg's shared default is
+        # lmbda_red = 1, which is right for the SART family (MATLAB SART/OS_SART/SIRT all
+        # default lambdared = 1) but wrong to inherit here. Set it before delegating so an
+        # explicit caller value still wins.
+        if "lmbda_red" not in kwargs:
+            kwargs.update(dict(lmbda_red=0.99))
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)
         if "maxl2err" not in kwargs:
             self.epsilon = (

--- a/Python/tigre/algorithms/pocs_algorithms.py
+++ b/Python/tigre/algorithms/pocs_algorithms.py
@@ -160,6 +160,14 @@ class initASD_POCS(IterativeReconAlg):
                 dtvg = dtvg * self.alpha_red
 
             self.beta *= self.beta_red
+            # The data step scales the back-projection by self.lmbda
+            # (iterative_recon_alg.update_image), not by self.beta. In the MATLAB
+            # reference these are ONE variable: the user option is called 'lambda' but
+            # is held internally as `beta`, which is applied in the data step, decayed
+            # here, and stop-tested below. Splitting it into two Python attributes left
+            # the decay on a float copy nobody reads, so lambda_red had no effect on
+            # the solver at all. Keep them in step.
+            self.lmbda = self.beta
             c = np.dot(dg_vec.reshape(-1,), dp_vec.reshape(-1,)) / max(
                 dg * dp, 1e-6
             )  # reshape ensures no copy is made.
@@ -334,6 +342,14 @@ class initPICCS(IterativeReconAlg):
                 dtvg = dtvg * self.alpha_red
 
             self.beta *= self.beta_red
+            # The data step scales the back-projection by self.lmbda
+            # (iterative_recon_alg.update_image), not by self.beta. In the MATLAB
+            # reference these are ONE variable: the user option is called 'lambda' but
+            # is held internally as `beta`, which is applied in the data step, decayed
+            # here, and stop-tested below. Splitting it into two Python attributes left
+            # the decay on a float copy nobody reads, so lambda_red had no effect on
+            # the solver at all. Keep them in step.
+            self.lmbda = self.beta
             c = np.dot(dg_vec.reshape(-1,), dp_vec.reshape(-1,)) / max(
                 dg * dp, 1e-6
             )  # reshape ensures no copy is made.
@@ -563,6 +579,14 @@ class initPCSD(IterativeReconAlg):
                 d_p_1st = im3DNORM(Ax(res_prev,self.geo,self.angles)-self.proj, 2)
 
             self.beta *= self.beta_red
+            # The data step scales the back-projection by self.lmbda
+            # (iterative_recon_alg.update_image), not by self.beta. In the MATLAB
+            # reference these are ONE variable: the user option is called 'lambda' but
+            # is held internally as `beta`, which is applied in the data step, decayed
+            # here, and stop-tested below. Splitting it into two Python attributes left
+            # the decay on a float copy nobody reads, so lambda_red had no effect on
+            # the solver at all. Keep them in step.
+            self.lmbda = self.beta
             c = np.dot(dg_vec.reshape(-1,), dp_vec.reshape(-1,)) / max(dg * dp, 1e-6) # reshape ensures no copy is made. 
             if (c < -0.99 and dd <=
                     self.epsilon) or self.beta < 0.005 or n_iter > self.niter:


### PR DESCRIPTION
### The problem

The POCS loops decay `self.beta` on every iteration, but the SART data step scales the
back-projection by `self.lmbda`:

```python
# pocs_algorithms.py, initASD_POCS.__init__
self.beta     = self.lmbda
self.beta_red = self.lmbda_red
...
# initASD_POCS.run_main_iter
self.beta *= self.beta_red
if (c < -0.99 and dd <= self.epsilon) or self.beta < 0.005 or n_iter >= self.niter:

# iterative_recon_alg.py, update_image
self.res += (self.lmbda * 1.0 / self.V[iteration] * Atb(...))
```

`self.beta = self.lmbda` copies a float, so `self.beta *= self.beta_red` rebinds only
`self.beta`. `self.lmbda` is never decayed anywhere in the Python tree, and `self.beta` is never
read outside the stop test. **The relaxation the solver applies is constant for the entire run,
and `lambda_red` has no effect.**

In the MATLAB reference these are one variable: the user option is called `lambda` but is held
internally as `beta`, which is applied in the data step (`ASD_POCS.m:159`,
`f = f + beta * ...`), decayed each iteration (`:211`), and used for the stop test (`:219`).
The Python port kept MATLAB's internal name for the decayed copy and its external name for the
applied value, and treated them as two variables.

### Reproducer

`OS_AwASD_POCS` with `lambda_red=0.5`, six iterations, instrumenting `update_image` to record
the factor it actually applies:

```text
before: relaxation applied per iteration [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
        alg.lmbda 1.000000   alg.beta 0.015625
after:  relaxation applied per iteration [1.0, 0.5, 0.25, 0.125, 0.0625, 0.03125]
        alg.lmbda 0.015625   alg.beta 0.015625
```

A user who asks for a halving each iteration currently gets a constant relaxation.

### Knock-on effect

Because the decay never reached the solver, the `beta < 0.005` stopping criterion degenerated
into `lambda_red ** n_iter` — a pure function of the iteration number, carrying no information
about the reconstruction. With `lambda_red` at its current default of 1 it can never fire at all.

### The second commit: the default

`IterativeReconAlg`'s shared defaults set `lmbda_red = 1`. That is correct for the SART family —
MATLAB `SART.m`, `OS_SART.m` and `SIRT.m` all default `lambdared = 1` — but the POCS classes
should not inherit it: MATLAB `ASD_POCS.m`, `PICCS.m` and `PCSD.m` all default
`beta_red = 0.99`.

It is set in the three POCS base constructors rather than in the shared defaults, so the SART
family is untouched and an explicit caller value still wins. Split into its own commit because
it is a behaviour change, and it is inert without the first commit — happy to drop it if you
would rather keep defaults frozen.

### Scope

`Python/tigre/algorithms/pocs_algorithms.py` only, all three base classes (`initASD_POCS`,
`initPICCS`, `initPCSD`). No MATLAB changes. No change to the SART/SIRT families. Line endings
(CRLF) preserved, so the diff is 45 added lines and nothing else.

### How this was found

Auditing a sparse-view CBCT study where we drive an ASD-POCS loop ourselves and had assumed our
hand-rolled relaxation decay was equivalent to the packaged solver's.
