### PR TITLE
TV/PICCS minimizers destroy the caller's CUDA context on success; IRN_TV_CGLS broken under NumPy 2

### DIFF
--- a/Common/CUDA/GD_TV.cu
+++ b/Common/CUDA/GD_TV.cu
@@ -678,7 +678,18 @@ do { \
             cudaDeviceSynchronize();
         }
         cudaCheckErrors("Memory free");
-        cudaDeviceReset();
+        // Do NOT cudaDeviceReset() here: it destroys the PRIMARY CUDA
+        // CONTEXT of the whole host process, not just this function's
+        // resources - every allocation, module and stream the caller holds
+        // through CuPy, PyTorch (see the d25 bindings) or any other CUDA
+        // library dies with it. TIGRE's own subsequent kernels survive only
+        // because the runtime silently re-creates the context, so the
+        // symptom appears in the NEXT library to touch the GPU (e.g.
+        // cudaErrorInvalidValue / CUDA_ERROR_INVALID_HANDLE inside CuPy
+        // deallocations) rather than in TIGRE itself. All buffers are
+        // already freed explicitly above; GD_AwTV.cu has this reset
+        // commented out for the same reason.
+        // cudaDeviceReset();
     }
         
 void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){

--- a/Common/CUDA/PICCS.cu
+++ b/Common/CUDA/PICCS.cu
@@ -393,6 +393,10 @@ bool isnan_cuda(float* vec, size_t size){
 
 
         cudaCheckErrors("Memory free");
-        cudaDeviceReset();
+        // Do NOT cudaDeviceReset() here - it destroys the whole host
+        // process's primary CUDA context (CuPy/PyTorch state included),
+        // not just this function's resources. See the matching note in
+        // GD_TV.cu; all buffers are already freed explicitly above.
+        // cudaDeviceReset();
     }
     


### PR DESCRIPTION
Two independent fixes, found together while running the POCS family from a host process that also uses CuPy.

1. minimizeTV (GD_TV.cu) and PICCS (PICCS.cu) end their successful path with cudaDeviceReset(). A device reset destroys the primary CUDA context of the whole host process — every allocation, module and stream the caller holds through CuPy, PyTorch (the d25 bindings), or any other CUDA library dies with it. TIGRE's own subsequent kernels survive because the runtime silently re-creates the context, so the failure surfaces in the next library to touch the GPU (cudaErrorInvalidValue inside CuPy deallocations, then CUDA_ERROR_INVALID_HANDLE) and looks like a bug in whatever ran after asd_pocs/os_asd_pocs/sart_tv rather than in TIGRE. Minimal repro: hold a live cupy array, run asd_pocs, then read the array. All device buffers are freed explicitly before the reset, so it protects nothing; GD_AwTV.cu has had the same reset commented out for a long time.

2. IRN_TV_CGLS cannot complete one iteration under NumPy 2 — completes a86e30d: the sqrt(lmbda) sites were fixed there, but gamma/alpha/beta come from np.linalg.norm(...)**2, a float64 scalar. With NEP 50, self.res + alpha*p promotes the volume to float64 and the next Ax raises Input data should be float32, not float64. Cast the step scalars to np.float32.

Verified on RTX 6000 Ada / CUDA 13 / NumPy 2.5: after the fix a CuPy array survives an asd_pocs call and irn_tv_cgls runs to completion in float32.