### PR TITLE
Shared parseCommonInputs utility -- scoped proof-of-concept for #378

### DIFF
--- a/MATLAB/Algorithms/CGLS.m
+++ b/MATLAB/Algorithms/CGLS.m
@@ -136,22 +136,26 @@ end
 
 %% parse inputs'
 function [verbose,x,QualMeasOpts,gpuids,gt,restart]=parse_inputs(proj,geo,angles,argin)
-opts=     {'init','initimg','verbose','qualmeas','gpuids','groundtruth','restart'};
+[common, leftover] = parseCommonInputs(proj, geo, angles, argin, 'CGLS');
+verbose      = common.verbose;
+x            = common.res;
+QualMeasOpts = common.QualMeasOpts;
+gpuids       = common.gpuids;
+gt           = common.gt;
+
+% Algorithm-specific options
+opts=     {'restart'};
 defaults=ones(length(opts),1);
 
 % Check inputs
-nVarargs = length(argin);
-if mod(nVarargs,2)
-    error('TIGRE:CGLS:InvalidInput','Invalid number of inputs')
-end
-
+nVarargs = length(leftover);
 % check if option has been passed as input
 for ii=1:2:nVarargs
-    ind=find(ismember(opts,lower(argin{ii})));
+    ind=find(ismember(opts,lower(leftover{ii})));
     if ~isempty(ind)
         defaults(ind)=0;
     else
-        error('TIGRE:CGLS:InvalidInput',['Optional parameter "' argin{ii} '" does not exist' ]);
+        error('TIGRE:CGLS:InvalidInput',['Optional parameter "' leftover{ii} '" does not exist' ]);
     end
 end
 
@@ -160,84 +164,18 @@ for ii=1:length(opts)
     default=defaults(ii);
     % if one option isnot default, then extranc value from input
     if default==0
-        ind=double.empty(0,1);jj=1;
+        ind=[];jj=1;
         while isempty(ind)
-            ind=find(isequal(opt,lower(argin{jj})));
+            ind=find(isequal(opt,lower(leftover{jj})));
             jj=jj+1;
         end
         if isempty(ind)
-            error('TIGRE:CGLS:InvalidInput',['Optional parameter "' argin{jj} '" does not exist' ]);
+            error('TIGRE:CGLS:InvalidInput',['Optional parameter "' leftover{jj} '" does not exist' ]);
         end
-        val=argin{jj};
+        val=leftover{jj};
     end
-    
+
     switch opt
-        case 'init'
-            x=[];
-            if default || strcmp(val,'none')
-                x=zeros(geo.nVoxel','single');
-                continue;
-            end
-            if strcmp(val,'FDK')
-                x=FDK(proj,geo,angles);
-                continue;
-            end
-            if strcmp(val,'multigrid')
-                x=init_multigrid(proj,geo,angles);
-                continue;
-            end
-            if strcmp(val,'image')
-                initwithimage=1;
-                continue;
-            end
-            if isempty(x)
-                error('TIGRE:CGLS:InvalidInput','Invalid Init option')
-            end
-            % % % % % % % ERROR
-        case 'initimg'
-            if default
-                continue;
-            end
-            if exist('initwithimage','var')
-                if isequal(size(val),geo.nVoxel')
-                    x=single(val);
-                else
-                    error('TIGRE:CGLS:InvalidInput','Invalid image for initialization');
-                end
-            end
-            %  =========================================================================
-        case 'qualmeas'
-            if default
-                QualMeasOpts={};
-            else
-                if iscellstr(val)
-                    QualMeasOpts=val;
-                else
-                    error('TIGRE:CGLS:InvalidInput','Invalid quality measurement parameters');
-                end
-            end
-        case 'verbose'
-            if default
-                verbose=1;
-            else
-                verbose=val;
-            end
-            if ~is2014bOrNewer
-                warning('TIGRE:Verbose mode not available for older versions than MATLAB R2014b');
-                verbose=false;
-            end
-        case 'gpuids'
-            if default
-                gpuids = GpuIds();
-            else
-                gpuids = val;
-            end
-        case 'groundtruth'
-            if default
-                gt=nan;
-            else
-                gt=val;
-            end
         case 'restart'
             if default
                 restart=true;
@@ -248,6 +186,5 @@ for ii=1:length(opts)
             error('TIGRE:CGLS:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in CGLS()']);
     end
 end
-
 
 end

--- a/MATLAB/Algorithms/SIRT.m
+++ b/MATLAB/Algorithms/SIRT.m
@@ -223,21 +223,26 @@ end
 
 
 function [lambda,res,lambdared,verbose,QualMeasOpts,nonneg,gpuids,redundancy_weights,gt]=parse_inputs(proj,geo,alpha,argin)
-opts={'lambda','init','initimg','verbose','lambda_red','qualmeas','nonneg','gpuids','redundancy_weighting','groundtruth'};
-defaults=ones(length(opts),1);
-% Check inputs
-nVarargs = length(argin);
-if mod(nVarargs,2)
-    error('TIGRE:SIRT:InvalidInput','Invalid number of inputs')
-end
+[common, leftover] = parseCommonInputs(proj, geo, alpha, argin, 'SIRT', @init_multigrid);
+verbose      = common.verbose;
+res          = common.res;
+QualMeasOpts = common.QualMeasOpts;
+gpuids       = common.gpuids;
+gt           = common.gt;
 
+% Algorithm-specific options
+opts={'lambda','lambda_red','nonneg','redundancy_weighting'};
+defaults=ones(length(opts),1);
+
+% Check inputs
+nVarargs = length(leftover);
 % check if option has been passed as input
 for ii=1:2:nVarargs
-    ind=find(ismember(opts,lower(argin{ii})));
+    ind=find(ismember(opts,lower(leftover{ii})));
     if ~isempty(ind)
         defaults(ind)=0;
     else
-        error('TIGRE:SIRT:InvalidInput',['Optional parameter "' argin{ii} '" does not exist' ]);
+        error('TIGRE:SIRT:InvalidInput',['Optional parameter "' leftover{ii} '" does not exist' ]);
     end
 end
 
@@ -246,30 +251,19 @@ for ii=1:length(opts)
     default=defaults(ii);
     % if one option is not default, then extract value from input
     if default==0
-        ind=double.empty(0,1);jj=1;
+        ind=[];jj=1;
         while isempty(ind)
-            ind=find(isequal(opt,lower(argin{jj})));
+            ind=find(isequal(opt,lower(leftover{jj})));
             jj=jj+1;
         end
         if isempty(ind)
-            error('TIGRE:SIRT:InvalidInput',['Optional parameter "' argin{jj} '" does not exist' ]);
+            error('TIGRE:SIRT:InvalidInput',['Optional parameter "' leftover{jj} '" does not exist' ]);
         end
-        val=argin{jj};
+        val=leftover{jj};
     end
-    
+
     switch opt
-        % % % % % % % Verbose
-        case 'verbose'
-            if default
-                verbose=1;
-            else
-                verbose=val;
-            end
-            if ~is2014bOrNewer
-                warning('TIGRE: Verbose mode not available for older versions than MATLAB R2014b');
-                verbose=false;
-            end
-            % % % % % % % hyperparameter, LAMBDA
+        % % % % % % % hyperparameter, LAMBDA
         case 'lambda'
             if default
                 lambda=1;
@@ -289,72 +283,17 @@ for ii=1:length(opts)
                 end
                 lambdared=val;
             end
-        case 'init'
-            res=[];
-            if default || strcmp(val,'none')
-                res=zeros(geo.nVoxel','single');
-                continue
-            end
-            if strcmp(val,'FDK')
-                res=FDK(proj,geo,alpha);
-                continue
-            end
-            if strcmp(val,'multigrid')
-                res=init_multigrid(proj,geo,alpha);
-                continue
-            end
-            if strcmp(val,'image')
-                initwithimage=1;
-                continue
-            end
-            if isempty(res)
-                error('TIGRE:SIRT:InvalidInput','Invalid Init option')
-            end
-            % % % % % % % ERROR
-        case 'initimg'
-            if default
-                continue
-            end
-            if exist('initwithimage','var')
-                if isequal(size(val),geo.nVoxel')
-                    res=single(val);
-                else
-                    error('TIGRE:SIRT:InvalidInput','Invalid image for initialization');
-                end
-            end
-        case 'qualmeas'
-            if default
-                QualMeasOpts={};
-            else
-                if iscellstr(val)
-                    QualMeasOpts=val;
-                else
-                    error('TIGRE:SIRT:InvalidInput','Invalid quality measurement parameters');
-                end
-            end
         case 'nonneg'
             if default
                 nonneg=true;
             else
                 nonneg=val;
             end
-        case 'gpuids'
-            if default
-                gpuids = GpuIds();
-            else
-                gpuids = val;
-            end
         case 'redundancy_weighting'
             if default
                 redundancy_weights = true;
             else
                 redundancy_weights = val;
-            end
-        case 'groundtruth'
-            if default
-                gt=nan;
-            else
-                gt=val;
             end
         otherwise
             error('TIGRE:SIRT:InvalidInput',['Invalid input name:', num2str(opt),'\n No such option in SIRT()']);

--- a/MATLAB/Utilities/parseCommonInputs.m
+++ b/MATLAB/Utilities/parseCommonInputs.m
@@ -1,4 +1,4 @@
-function [common, leftover] = parseCommonInputs(proj, geo, angles, argin, algName)
+function [common, leftover] = parseCommonInputs(proj, geo, angles, argin, algName, multigridFn)
 %PARSECOMMONINPUTS Parses the option name/value pairs shared by (almost)
 % all TIGRE reconstruction algorithms.
 %
@@ -23,6 +23,20 @@ function [common, leftover] = parseCommonInputs(proj, geo, angles, argin, algNam
 % ALGNAME is used only to build 'TIGRE:<ALGNAME>:InvalidInput' error
 % identifiers, matching each algorithm's pre-existing error IDs.
 %
+% [...] = PARSECOMMONINPUTS(..., MULTIGRIDFN) lets the caller supply its
+% own INIT_MULTIGRID implementation as a function handle. This matters
+% because init_multigrid is NOT a shared utility in TIGRE -- it is
+% duplicated as a local (file-private) function inside several
+% algorithms (e.g. SART, SIRT, OSEM), each only visible within its own
+% file. If MULTIGRIDFN is omitted, this defaults to a bare @init_multigrid
+% handle resolved from THIS file's scope, which preserves each
+% algorithm's pre-existing behavior exactly: algorithms with no global
+% init_multigrid on the path (e.g. CGLS, which already lacks one today)
+% keep failing with the same "undefined function" error as before, while
+% algorithms that define their own local init_multigrid (e.g. SIRT) must
+% pass a handle to it (e.g. @init_multigrid, created from within their
+% own file's scope) to keep 'init','multigrid' working as it does today.
+%
 % NOTE on preserved (not "fixed") behavior: matching every existing
 % algorithm's current implementation, if 'init' is set to 'image' but
 % 'initimg' is not supplied, COMMON.RES is left as [] without raising an
@@ -43,6 +57,10 @@ function [common, leftover] = parseCommonInputs(proj, geo, angles, argin, algNam
 % Contact: tigre.toolbox@gmail.com
 % Codes: https://github.com/CERN/TIGRE/
 %--------------------------------------------------------------------------
+
+if nargin < 6 || isempty(multigridFn)
+    multigridFn = @init_multigrid;
+end
 
 commonOpts = {'init','initimg','verbose','qualmeas','gpuids','groundtruth'};
 
@@ -91,7 +109,7 @@ if (~has('init')) || (ischar(initVal) && strcmp(initVal,'none'))
 elseif ischar(initVal) && strcmp(initVal,'FDK')
     common.res = FDK(proj,geo,angles);
 elseif ischar(initVal) && strcmp(initVal,'multigrid')
-    common.res = init_multigrid(proj,geo,angles);
+    common.res = multigridFn(proj,geo,angles);
 elseif ischar(initVal) && strcmp(initVal,'image')
     if has('initimg')
         initimgVal = value('initimg');

--- a/MATLAB/Utilities/parseCommonInputs.m
+++ b/MATLAB/Utilities/parseCommonInputs.m
@@ -1,0 +1,135 @@
+function [common, leftover] = parseCommonInputs(proj, geo, angles, argin, algName)
+%PARSECOMMONINPUTS Parses the option name/value pairs shared by (almost)
+% all TIGRE reconstruction algorithms.
+%
+% [COMMON, LEFTOVER] = PARSECOMMONINPUTS(PROJ, GEO, ANGLES, ARGIN, ALGNAME)
+% parses ARGIN (an algorithm's varargin, as a cell array) for the options
+% shared across TIGRE's iterative algorithms -- 'init', 'initimg',
+% 'verbose', 'qualmeas', 'gpuids', 'groundtruth' -- and returns them as
+% fields of the struct COMMON:
+%
+%   common.res           - initial image, resolved from 'init'/'initimg'
+%   common.verbose        - verbose flag
+%   common.QualMeasOpts   - quality measure cell array
+%   common.gpuids         - GpuIds object
+%   common.gt             - ground truth image (or nan if not given)
+%
+% Any name/value pairs in ARGIN that are not among the common options
+% (e.g. an algorithm-specific option like 'lambda' or 'restart') are
+% left untouched, in their original order, in the cell array LEFTOVER,
+% so the calling algorithm can parse its own remaining options from
+% LEFTOVER exactly as it parsed the full ARGIN before this refactor.
+%
+% ALGNAME is used only to build 'TIGRE:<ALGNAME>:InvalidInput' error
+% identifiers, matching each algorithm's pre-existing error IDs.
+%
+% NOTE on preserved (not "fixed") behavior: matching every existing
+% algorithm's current implementation, if 'init' is set to 'image' but
+% 'initimg' is not supplied, COMMON.RES is left as [] without raising an
+% error here -- this mirrors the pre-refactor behavior exactly. This is
+% arguably a latent bug worth its own separate issue, but changing it is
+% out of scope for this structural refactor.
+%--------------------------------------------------------------------------
+% This file is part of the TIGRE Toolbox
+%
+% Copyright (c) 2015, University of Bath and
+% CERN-European Organization for Nuclear Research
+% All rights reserved.
+%
+% License: Open Source under BSD.
+% See the full license at
+% https://github.com/CERN/TIGRE/blob/master/LICENSE
+%
+% Contact: tigre.toolbox@gmail.com
+% Codes: https://github.com/CERN/TIGRE/
+%--------------------------------------------------------------------------
+
+commonOpts = {'init','initimg','verbose','qualmeas','gpuids','groundtruth'};
+
+nVarargs = length(argin);
+if mod(nVarargs,2)
+    error(['TIGRE:' algName ':InvalidInput'],'Invalid number of inputs')
+end
+
+leftover = {};
+value = containers.Map('KeyType','char','ValueType','any');
+present = containers.Map('KeyType','char','ValueType','logical');
+
+for ii=1:2:nVarargs
+    key = lower(argin{ii});
+    if ismember(key, commonOpts)
+        value(key) = argin{ii+1};
+        present(key) = true;
+    else
+        leftover{end+1} = argin{ii}; %#ok<AGROW>
+        leftover{end+1} = argin{ii+1}; %#ok<AGROW>
+    end
+end
+
+has = @(k) isKey(present, k);
+
+% % % % % % % Verbose
+if has('verbose')
+    common.verbose = value('verbose');
+else
+    common.verbose = 1;
+end
+if ~is2014bOrNewer
+    warning(['TIGRE:' algName],'Verbose mode not available for older versions than MATLAB R2014b');
+    common.verbose = false;
+end
+
+% % % % % % % Init / Initimg
+if has('init')
+    initVal = value('init');
+else
+    initVal = 'none';
+end
+common.res = [];
+if (~has('init')) || (ischar(initVal) && strcmp(initVal,'none'))
+    common.res = zeros(geo.nVoxel','single');
+elseif ischar(initVal) && strcmp(initVal,'FDK')
+    common.res = FDK(proj,geo,angles);
+elseif ischar(initVal) && strcmp(initVal,'multigrid')
+    common.res = init_multigrid(proj,geo,angles);
+elseif ischar(initVal) && strcmp(initVal,'image')
+    if has('initimg')
+        initimgVal = value('initimg');
+        if isequal(size(initimgVal),geo.nVoxel')
+            common.res = single(initimgVal);
+        else
+            error(['TIGRE:' algName ':InvalidInput'],'Invalid image for initialization');
+        end
+    end
+    % else: preserved quirk -- res stays [], see NOTE above.
+else
+    error(['TIGRE:' algName ':InvalidInput'],'Invalid Init option')
+end
+
+% % % % % % % Quality measures
+if has('qualmeas')
+    v = value('qualmeas');
+    if iscellstr(v)
+        common.QualMeasOpts = v;
+    else
+        error(['TIGRE:' algName ':InvalidInput'],'Invalid quality measurement parameters');
+    end
+else
+    common.QualMeasOpts = {};
+end
+
+% % % % % % % GPU ids
+if has('gpuids')
+    common.gpuids = value('gpuids');
+else
+    common.gpuids = GpuIds();
+end
+
+% % % % % % % Ground truth
+if has('groundtruth')
+    common.gt = value('groundtruth');
+else
+    common.gt = nan;
+end
+
+end


### PR DESCRIPTION
Addresses #378 -- but scoped intentionally, and I'd like your input on direction before going further.

## What this is

`parse_inputs()` is duplicated across all 26 algorithm files, and most of that duplication is identical: `init`/`initimg`, `verbose`, `qualmeas`, `gpuids`, `groundtruth`. This PR extracts that shared portion into `MATLAB/Utilities/parseCommonInputs.m`, and migrates **two** algorithms (CGLS and SIRT) as a proof of concept, rather than attempting all 26 at once.

Each migrated algorithm's own `parse_inputs` now just calls `parseCommonInputs` for the common options, then parses its own remaining algorithm-specific options (e.g. CGLS's `restart`; SIRT's `lambda`, `lambda_red`, `nonneg`, `redundancy_weighting`) from the leftover argument list, exactly as before.

## Why only 2 algorithms, not all 26

This touches option-parsing for real reconstruction algorithms that people run on real scan data, so I didn't want to blind-rewrite all 26 in one pass without your sign-off on the approach. A few things came up even in just these two that I think are worth your eyes before scaling this up:

1. **A bug found and fixed**: `ind=double.empty(0,1)` (present in every algorithm's parse_inputs) relies on MATLAB's classdef static-method syntax and isn't portable (fails under GNU Octave, for instance). Replaced with `ind=[]` -- identical behavior, more portable. I did NOT change this in the other 24 files, only the 2 migrated here.
2. **A design subtlety**: `init_multigrid` is not a shared utility -- it's duplicated as a local (file-private) function inside several algorithms (SART, SIRT, OSEM, OS_SART, SART_TV), each only visible within its own file. A shared parser calling `init_multigrid(...)` directly would silently break any algorithm whose own copy isn't globally visible. `parseCommonInputs` takes an optional function handle for this (`multigridFn`) so each algorithm can pass its own local implementation; SIRT does this (`@init_multigrid`, created inside SIRT.m so it correctly captures SIRT's own local function). CGLS doesn't have its own `init_multigrid` at all today (calling `'Init','multigrid'` on CGLS already errors with "undefined function" before this PR) -- that's a pre-existing gap, unrelated to this refactor, and I've left it alone.
3. **A preserved (not fixed) quirk**: if `'init','image'` is passed without `'initimg'`, every existing algorithm silently leaves the result empty rather than erroring. I kept this exact behavior in `parseCommonInputs` rather than "fixing" it, since this PR is meant to be structural only. Flagging it here in case it's worth its own issue.

## Testing

I don't have a MATLAB license in my environment, so I used GNU Octave to actually execute the code rather than just writing it and hoping:
- Unit-tested `parseCommonInputs` directly (defaults, every option, error paths, the preserved quirks above).
- Side-by-side equivalence tests: ran the original and migrated `parse_inputs` for both CGLS and SIRT against 12-14 cases each and diffed every output field -- all matched, including error identifiers.
- A targeted test confirming the `multigridFn` handle actually resolves to the caller's own local function and not some other `init_multigrid`, using a deliberately "wrong" decoy to make sure.

I have not been able to verify against real MATLAB specifically, only Octave -- flagging that as a limitation.

If this approach looks right to you, I'm happy to continue migrating the remaining 24 algorithms in follow-up PRs. If you'd rather see a different shape (e.g. a struct-based options object instead of a leftover-args split, or algorithm name dispatch as you originally suggested), let me know before I put more algorithms through this pattern.