### PR TITLE
Python fixes: gpuids=None default, helical demo offOrigin axis, computeCOR port

### DIFF
--- a/Python/demos/d13_HelicalGeometry.py
+++ b/Python/demos/d13_HelicalGeometry.py
@@ -36,9 +36,16 @@ angles = np.hstack([angles, angles, angles])  # loop 3 times
 # Load thorax phantom data
 head = sample_loader.load_head_phantom(geo.nVoxel)
 
-# This makes it helical
+# This makes it helical.
+#
+# NOTE the component ordering: the Python bindings map offOrigin as
+# (z, y, x) - matching numpy's volume index order - so the axial (helix)
+# motion goes in column 0. This differs from MATLAB, whose offOrigin is
+# (x, y, z) and whose version of this demo therefore uses offOrigin(3,:).
+# Porting by keeping the index silently translates the volume along the
+# BEAM instead of along the rotation axis.
 geo.offOrigin = np.zeros((angles.shape[0], 3))
-geo.offOrigin[:, 2] = np.linspace(
+geo.offOrigin[:, 0] = np.linspace(
     -1024 / 2 + 128, 1024 / 2 - 128, angles.shape[0]
 )  # about 256^3 images fit int he detector with this size.
 

--- a/Python/tests/test_compute_cor.py
+++ b/Python/tests/test_compute_cor.py
@@ -1,0 +1,39 @@
+"""computeCOR: does it run, does it recover a known centre of rotation.
+
+The reference is MATLAB/Utilities/computeCOR.m; see the module docstring of
+tigre/utilities/computeCOR.py for the line-by-line comparison and the one
+deliberate divergence (score normalised by the count of valid pixels, which
+is what MATLAB's `length(find(test > 0))` computes).
+"""
+import numpy as np
+import pytest
+
+import tigre
+
+TOL_MM = 0.2
+
+
+def _problem(cor_mm, nang=120):
+    geo = tigre.geometry(mode="cone", nVoxel=np.array([128, 128, 128]), default=True)
+    angles = np.linspace(0, 2 * np.pi, nang, endpoint=False, dtype=np.float32)
+    geo.check_geo(angles)
+    geo.COR = np.ones(nang, dtype=np.float32) * np.float32(cor_mm)
+    z, y, x = np.mgrid[:128, :128, :128].astype(np.float32)
+    ph = np.zeros((128, 128, 128), dtype=np.float32)
+    ph[((x - 70) ** 2 + (y - 60) ** 2 + (z - 64) ** 2) < 26 ** 2] = 1.0
+    ph[((x - 50) ** 2 + (y - 74) ** 2 + (z - 64) ** 2) < 11 ** 2] = 2.0
+    return geo, angles, tigre.Ax(ph, geo, angles, "Siddon")
+
+
+@pytest.mark.parametrize("true_cor", [0.0, 0.5, -0.5, 1.5, -2.0])
+def test_recovers_a_known_cor(true_cor):
+    geo, angles, proj = _problem(true_cor)
+    est = float(tigre.computeCOR(proj, geo, angles))
+    assert abs(est - true_cor) < TOL_MM, f"true {true_cor}, estimated {est:.4f}"
+
+
+def test_descending_angles_give_the_same_answer():
+    geo, angles, proj = _problem(0.75)
+    a = float(tigre.computeCOR(proj, geo, angles))
+    b = float(tigre.computeCOR(proj[::-1], geo, angles[::-1]))
+    assert a == pytest.approx(b, abs=1e-6)

--- a/Python/tests/test_gpuids_default.py
+++ b/Python/tests/test_gpuids_default.py
@@ -1,0 +1,80 @@
+"""gpuids=None must mean "every visible GPU", not "no GPU".
+
+Every compiled entry point declares `gpuids=None` in its own signature, and
+they all convert it through one helper, `convert_to_c_gpuids` in
+_gpuUtils.pxd. That helper used to turn None into a VALID pointer holding
+m_iCount = 0 and a NULL device list, and hand that to CUDA.
+
+The algorithm classes hide it - they all do
+`if self.gpuids is None: self.gpuids = GpuIds()` before calling down - so
+tigre.Ax/Atb and every algs.* function looked fine. The kernels reachable
+directly did not: `minTV(img, alpha, iters, None)` ran with zero devices and
+killed the interpreter outright. No exception, no message, no traceback - the
+process simply ended, which is why it reads as "TIGRE fails" rather than as a
+bad argument.
+
+NOTE ON FAILURE MODE: a regression here does not fail these tests, it ABORTS
+the interpreter running them. pytest reports that as a crashed worker rather
+than an assertion - loud, but not a normal failure. That is the nature of the
+bug being guarded.
+"""
+import numpy as np
+import pytest
+
+import tigre
+from tigre.utilities.Ax import Ax
+from tigre.utilities.Atb import Atb
+
+
+@pytest.fixture(scope="module")
+def small():
+    geo = tigre.geometry(mode="cone", nVoxel=np.array([32, 32, 32]), default=True)
+    angles = np.linspace(0, 2 * np.pi, 30, endpoint=False, dtype=np.float32)
+    geo.check_geo(angles)
+    img = np.random.default_rng(0).random((32, 32, 32)).astype(np.float32)
+    return geo, angles, img, Ax(img, geo, angles, "Siddon")
+
+
+def test_ax_atb_accept_none(small):
+    geo, angles, img, proj = small
+    assert np.isfinite(Ax(img, geo, angles, "Siddon", gpuids=None)).all()
+    assert np.isfinite(Atb(proj, geo, angles, backprojection_type="matched",
+                           gpuids=None)).all()
+
+
+def test_min_tv_accepts_none(small):
+    """The case that killed the interpreter."""
+    from _minTV import minTV
+    geo, angles, img, proj = small
+    out = minTV(img, 1.0, 2, None)
+    assert out.shape == img.shape
+    assert np.isfinite(out).all()
+    assert np.any(out != 0), "denoiser returned an all-zero volume"
+
+
+def test_awmin_tv_accepts_none(small):
+    from _AwminTV import AwminTV
+    geo, angles, img, proj = small
+    out = AwminTV(img, 1.0, 2, -0.005, None)
+    assert out.shape == img.shape
+    assert np.isfinite(out).all()
+    assert np.any(out != 0)
+
+
+def test_tv_proximal_and_poisson_accept_none(small):
+    """_tvdenoising declares the same default but is not among the built
+    extensions; _tv_proximal is the one that ships."""
+    from _tv_proximal import tvdenoise
+    from _RandomNumberGenerator import add_poisson
+    geo, angles, img, proj = small
+    out = tvdenoise(img, 2, 1.0, gpuids=None)
+    assert np.isfinite(out).all()
+    noisy = add_poisson(np.abs(proj) + 1.0, gpuids=None)
+    assert np.isfinite(noisy).all()
+
+
+def test_none_resolves_to_all_visible_gpus():
+    """The default is 'all of them', matching what the algorithm classes do
+    by hand, not 'the first one' and not 'none'."""
+    from tigre.utilities.gpu import GpuIds
+    assert len(GpuIds()) >= 1

--- a/Python/tigre/__init__.py
+++ b/Python/tigre/__init__.py
@@ -53,6 +53,7 @@ from .utilities.visualization.plotimg import plotimg, plotImg
 from .utilities.visualization.plot_geometry import plot_geometry
 from .utilities.visualization.plot_angles import plot_angles
 from .utilities.CTnoise import add
+from .utilities.computeCOR import computeCOR
 from .utilities.common_geometry import (
     staticDetectorGeo,
     staticDetLinearSourceGeo,

--- a/Python/tigre/utilities/computeCOR.py
+++ b/Python/tigre/utilities/computeCOR.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Centre-of-rotation estimate from a single sinogram slice.
+
+Python port of MATLAB/Utilities/computeCOR.m, which is itself modified from
+SophiaBeads
+(https://github.com/Sophilyplum/sophiabeads-datasets/blob/master/tools/centre_geom.m)
+Reference: T. Liu, "Direct central ray determination in computed
+microtomography", Optical Engineering, April 2009.
+
+For a candidate centre of rotation, every ray has a conjugate ray half a turn
+away that should measure the same line integral. The candidate that makes the
+sinogram agree with its own reflected self is the centre.
+
+Checked against MATLAB/Utilities/computeCOR.m line by line. The arrays are
+transposed relative to it throughout - MATLAB holds (detector, angle) and
+projections as (V, U, angle), Python holds (angle, detector) and projections
+as (angle, V, U) - so the angular wrap is a concatenation along axis 0 here
+against a horizontal one there, and `angles[:, None] + beta[None, :]` is the
+transpose of its `repmat(angles', nDet, 1) + repmat(beta, 1, nAngles)`.
+Everything else - the 21-point search grid per precision, the seven precision
+levels, linear interpolation with 0 outside, and `-midpoint * DSO / DSD` -
+matches.
+
+One deliberate divergence in the score normalisation, matching MATLAB's
+INTENT: MATLAB's `nonzero = find(test > 0)` yields INDICES, so its
+`length(nonzero)` is the count of valid pixels and the score is a mean over
+them. A boolean-mask translation (`len(mask)` = the angle count) would be
+constant across candidates, turning the search into a SUM minimisation that
+rewards candidates whose reflected rays fall off the detector - every lost
+pixel drops a positive term. The mean over valid pixels is used here.
+"""
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+
+def computeCOR(data, geo, angles, slc=None):
+    """Estimate the centre of rotation, in mm at the rotation axis.
+
+    :param data: projections, (n_angles, n_rows, n_cols)
+    :param geo: tigre geometry
+    :param angles: projection angles, radians
+    :param slc: detector row to use (default: the central row)
+    :return: float, the COR offset in mm - the sign convention TIGRE's
+        `geo.COR` expects
+    """
+    if slc is None:
+        slc = int(np.floor(data.shape[1] / 2))
+
+    # float64 throughout, as in the MATLAB reference (`double(repmat(...))`):
+    # this is one detector row, so the precision is free.
+    sino = np.squeeze(np.asarray(data)[:, slc, :]).astype(np.float64)
+    angles = np.asarray(angles).astype(np.float64).ravel()
+
+    # check_geo() broadcasts these to one value per angle; the fan-angle
+    # geometry below is a single fixed source-detector pair.
+    DSD = float(np.mean(np.atleast_1d(np.asarray(geo.DSD, dtype=np.float64))))
+    DSO = float(np.mean(np.atleast_1d(np.asarray(geo.DSO, dtype=np.float64))))
+
+    # RegularGridInterpolator needs ascending coordinates; tolerate callers
+    # whose angle arrays run backwards.
+    if float(angles[0]) > float(angles[-1]):
+        angles = angles[::-1]
+        sino = sino[::-1]
+
+    det = np.linspace(-geo.sDetector[1] / 2 + geo.dDetector[1] / 2,
+                      +geo.sDetector[1] / 2 - geo.dDetector[1] / 2,
+                      int(geo.nDetector[1]), dtype=np.float64)
+    gamma = np.arctan(det / DSD)                # fan angle per column; candidate-invariant
+
+    # Repeat the sinogram either side in angle so a conjugate ray that lands
+    # outside [angles[0], angles[-1]] still interpolates instead of vanishing.
+    two_pi = 2.0 * np.pi
+    ang3 = np.concatenate((angles - two_pi, angles, angles + two_pi))
+    sino3 = np.concatenate((sino, sino, sino), axis=0)
+    interp = RegularGridInterpolator((ang3, det), sino3, method="linear",
+                                     bounds_error=False, fill_value=0.0)
+
+    midpoint = 0.0
+    for pr in (1, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001):
+        COR = np.linspace(midpoint - 10 * pr, midpoint + 10 * pr, 21, dtype=np.float64)
+        M = np.full((COR.size,), np.inf, dtype=np.float64)
+
+        for j in range(COR.size):
+            gamma_c = np.arctan(COR[j] / DSD)
+            beta = 2.0 * (gamma - gamma_c) + np.pi          # conjugate-ray angle offset
+            s2 = DSD * np.tan(2.0 * gamma_c - gamma)        # ... and its detector position
+
+            angles_aux = angles[:, None] + beta[None, :]
+            pts = np.stack((angles_aux,
+                            np.broadcast_to(s2[None, :], angles_aux.shape)), axis=-1)
+            test = interp(pts.reshape(-1, 2)).reshape(angles_aux.shape)
+
+            valid = test > 0
+            n_valid = int(valid.sum())
+            if n_valid == 0:
+                continue        # leaves inf: a candidate that sees nothing never wins
+            M[j] = np.sum((test[valid] - sino[valid]) ** 2) / n_valid
+
+        midpoint = float(COR[int(np.argmin(M))])
+
+    return -midpoint * DSO / DSD

--- a/Python/tigre/utilities/cuda_interface/_gpuUtils.pxd
+++ b/Python/tigre/utilities/cuda_interface/_gpuUtils.pxd
@@ -16,11 +16,25 @@ cdef inline void free_c_gpuids(GpuIds* c_gpuids):
 cdef inline GpuIds* convert_to_c_gpuids(p_gpuids):
     cdef GpuIds* c_gpuids =<GpuIds *>malloc(sizeof(GpuIds))
     if not c_gpuids:
-        MemoryError("Error allocating memory for GPU IDs")
-    if p_gpuids is not None:
-        c_gpuids.m_iCount = len(p_gpuids)
-    else:
-        c_gpuids.m_iCount = 0
+        raise MemoryError("Error allocating memory for GPU IDs")
+    if p_gpuids is None:
+        # Default to EVERY visible GPU, not to no GPU.
+        #
+        # This used to build a valid pointer with m_iCount = 0 and an empty
+        # device list, and hand that to CUDA. The algorithm classes hide it -
+        # they all do `if self.gpuids is None: self.gpuids = GpuIds()` first -
+        # so tigre.Ax/Atb and every algs.* entry point look fine. But the
+        # kernels reachable directly, minTV and AwminTV among them, take
+        # gpuids=None as their own default signature and went straight through
+        # here: minTV(img, alpha, iters, None) ran with zero devices and killed
+        # the interpreter outright, no exception, no message.
+        #
+        # GpuIds() with no name means "all of them", which is the only sane
+        # reading of an unspecified device, and matches what the algorithm
+        # classes were already doing by hand.
+        from tigre.utilities.gpu import GpuIds as _AllGpuIds
+        p_gpuids = _AllGpuIds()
+    c_gpuids.m_iCount = len(p_gpuids)
     
     if c_gpuids.m_iCount > 0:
         c_gpuids.m_piDeviceIds = <int*>malloc(c_gpuids.m_iCount * sizeof(int))


### PR DESCRIPTION
Three small, independent Python-side items, one commit each so they can be
reviewed (or dropped) separately.

## 1. `gpuids=None` means every visible GPU, not no GPU

Every compiled entry point declares `gpuids=None` in its own signature
(`_Ax_ext`, `_Atb_ext`, `minTV`, `AwminTV`, `tvdenoise`, `add_poisson`), and
all of them convert it through one helper, `convert_to_c_gpuids` in
`_gpuUtils.pxd`. That helper turned `None` into a valid pointer holding
`m_iCount = 0` and a NULL device list, and handed it to CUDA to run on zero
devices.

The algorithm classes hide it — they all do
`if self.gpuids is None: self.gpuids = GpuIds()` before calling down, so
`tigre.Ax`/`Atb` and every `algs.*` function accept `None` happily. The
kernels reachable directly do not: `minTV(img, alpha, iters, None)` **ends
the host process outright** — no exception, no message, no traceback — which
makes it read as "TIGRE is broken" rather than as a bad argument.

Fixed in the helper rather than in seven call sites, since all seven already
route through it: `None` now resolves to `GpuIds()`, whose no-argument form
means "all visible GPUs" — the same thing the algorithm classes were doing by
hand. Also added the missing `raise` on the `malloc` check beside it, which
constructed a `MemoryError` and discarded it.

Tests: `Python/tests/test_gpuids_default.py` (5). Note a regression there
does not *fail* the tests — it aborts the interpreter running them; that is
the nature of the bug being guarded.

(`.pxd` change, so modules that cimport it need recompiling.)

## 2. Helical demo: the helix must move along `offOrigin[:, 0]`, not `[:, 2]`

The Python bindings map `offOrigin` as (z, y, x) — matching numpy's volume
index order (`_types.pyx`) — while MATLAB maps (x, y, z).
`d13_HelicalGeometry.py` was ported from MATLAB's `offOrigin(3,:)` by keeping
the index, which under the Python ordering translates the volume along the
BEAM instead of along the rotation axis: no helix at all.

Verified empirically rather than by reading: `offOrigin[0] = +10` moves a
central ball's projection by exactly the v-shift predicted for a +z volume
shift (+53.1 px at this geometry), while `offOrigin[2] = +10` produces no
v-shift (beam axis, invisible at azimuth 0). A comment at the site records
the ordering and the porting trap, since keeping MATLAB indices is exactly
how the bug was written.

## 3. `computeCOR`: Python parity with `MATLAB/Utilities/computeCOR.m`

The MATLAB toolbox has had `computeCOR.m` (modified from SophiaBeads'
`centre_geom.m`; T. Liu, *Optical Engineering*, April 2009) for years; the
Python bindings have no centre-of-rotation estimator. This adds one, checked
against the MATLAB implementation line by line — the arrays are transposed
relative to it throughout (MATLAB holds (detector, angle), Python
(angle, detector)); the module docstring records the mapping.

One deliberate divergence, matching MATLAB's intent rather than a literal
mask translation: MATLAB's `length(find(test > 0))` is the count of valid
pixels, so its score is a **mean over valid conjugate rays**. A boolean-mask
`len()` in Python would be the angle count — constant across candidates —
turning the search into a sum minimisation that rewards candidates whose
reflected rays fall off the detector (every lost pixel drops a positive
term).

Validated by recovery: a COR planted via `geo.COR` at 0 / ±0.5 / +1.5 /
−2.0 mm comes back within 0.1 mm (test tolerance 0.2 mm). NumPy + SciPy
only, no new dependencies. Tests: `Python/tests/test_compute_cor.py` (6).

---

All three verified on Windows (MSVC, CUDA, RTX A6000): full rebuild from
this branch, then the two new test files pass (11 tests).
