### PR TITLE
Title: Krylov methods: float64 norm accumulation, working restarts, and results that were being discarded

### DIFF
--- a/Python/tests/test_krylov_restart_and_norms.py
+++ b/Python/tests/test_krylov_restart_and_norms.py
@@ -1,0 +1,137 @@
+"""CGLS: the float64 norm accumulator, and the restart that never restarted.
+
+Two independent defects, both invisible at demo sizes and both decisive at
+production ones:
+
+1. ``np.linalg.norm`` accumulates the sum of squares in the array's OWN dtype.
+   On a projection-sized float32 array the running sum saturates against the
+   increments still being added to it and the norm comes back LOW - measured
+   26 % low at 720 x 3072^2. Every Krylov step size is a ratio of such norms,
+   and the loss-of-orthogonality test compares consecutive ones.
+
+2. The port of MATLAB's CGLS.m dropped the OUTER of its two loops, so the
+   ``break`` that MATLAB uses to fall back and restart instead left
+   ``run_main_iter`` entirely. Together with a sentinel that reads
+   ``re_init_at_iteration + 1 == i`` against an initial 0 - true at i == 1 -
+   one lost step at the first iteration ended the reconstruction.
+
+Neither test needs a GPU: the numerics are pure numpy, and the control-flow
+test drives run_main_iter with scripted residual norms.
+"""
+import numpy as np
+import pytest
+
+from tigre.algorithms import krylov_subspace_algorithms as K
+
+
+def test_norm_is_accurate_where_float32_accumulation_saturates():
+    """Equal-magnitude terms: the accumulator grows while the terms do not.
+
+    The error accelerates with N rather than tracking sqrt(N) - it is
+    progressive saturation, not random walk - so this modest size shows the
+    effect while the production sizes in the module docstring show its bite.
+    """
+    n = 50_000_000
+    x = np.full(n, 1e-3, dtype=np.float32)
+    exact = np.sqrt(n) * 1e-3
+
+    accurate = float(K._norm(x))
+    naive = float(np.linalg.norm(x))
+    print(f"exact {exact:.6f}  helper {accurate:.6f}  np.linalg.norm {naive:.6f}")
+
+    assert accurate == pytest.approx(exact, rel=1e-5)
+    # The helper must return float32 so callers' dtypes are unchanged:
+    # these scalars multiply float32 volumes and Ax/Atb reject float64.
+    assert K._norm(x).dtype == np.float32
+
+
+def test_norm_matches_numpy_when_accumulation_is_safe():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(10_000, dtype=np.float32)
+    assert float(K._norm(x)) == pytest.approx(float(np.linalg.norm(x)), rel=1e-6)
+    # Non-float32 input is passed straight through.
+    y = rng.standard_normal(1000)
+    assert float(K._norm(y)) == pytest.approx(float(np.linalg.norm(y)), rel=1e-12)
+
+
+def _stub_cgls(monkeypatch, residuals, niter, restart=True):
+    """A CGLS instance whose residual norms follow `residuals`, no GPU.
+
+    Per inner iteration the projection-shaped norms are taken in the order
+    (q_norm, residual); volume-shaped norms are p_norm / s_norm. Returning 1.0
+    for everything except the residual keeps alpha and beta finite and makes
+    the residual sequence the only thing driving the control flow.
+    """
+    proj_shape, vol_shape = (4, 5, 5), (3, 3, 3)
+    alg = object.__new__(K.CGLS)
+    alg.niter = niter
+    alg.verbose = False
+    alg.Quameasopts = None
+    alg.restart = restart
+    alg.re_init_at_iteration = -1
+    alg.geo = None
+    alg.angles = np.zeros(proj_shape[0], dtype=np.float32)
+    alg.gpuids = None
+    alg.proj = np.zeros(proj_shape, dtype=np.float32)
+    alg.res = np.zeros(vol_shape, dtype=np.float32)
+
+    seen = {"proj_norms": 0, "restarts": 0, "residuals": []}
+
+    def fake_norm(x, ord=2):
+        x = np.asarray(x)
+        if x.size == int(np.prod(proj_shape)):
+            j = seen["proj_norms"]
+            seen["proj_norms"] += 1
+            if j % 2 == 0:                      # q_norm
+                return np.float32(1.0)
+            k = j // 2                          # residual for iteration k
+            v = residuals[min(k, len(residuals) - 1)]
+            seen["residuals"].append(v)
+            return np.float32(v)
+        return np.float32(1.0)
+
+    def fake_Ax(x, geo, angles, ktype, gpuids=None):
+        return np.zeros(proj_shape, dtype=np.float32)
+
+    def fake_Atb(x, geo, angles, backprojection_type=None, gpuids=None):
+        return np.zeros(vol_shape, dtype=np.float32)
+
+    monkeypatch.setattr(K, "_norm", fake_norm)
+    monkeypatch.setattr(K, "Ax", fake_Ax)
+    monkeypatch.setattr(K, "Atb", fake_Atb)
+    monkeypatch.setattr(K.tigre, "Ax", fake_Ax)
+    monkeypatch.setattr(K.tigre, "Atb", fake_Atb)
+
+    real_init = alg.initialize_algo
+    def counting_init():
+        seen["restarts"] += 1
+        return real_init()
+    alg.initialize_algo = counting_init
+    return alg, seen
+
+
+def test_a_lost_step_restarts_instead_of_ending_the_reconstruction(monkeypatch):
+    """Residual rises once at iteration 1, then falls: must run all niter."""
+    residuals = [10.0, 11.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0]
+    alg, seen = _stub_cgls(monkeypatch, residuals, niter=6)
+    alg.run_main_iter()
+
+    # One rebuild at entry, one more for the restart - and crucially the run
+    # did not stop at i == 1: every iteration slot was filled.
+    assert seen["restarts"] == 2
+    assert np.count_nonzero(alg.l2l[0]) == 6
+
+
+def test_repeated_failure_at_the_same_iteration_still_gives_up(monkeypatch):
+    """The restart is allowed one chance, exactly as in the MATLAB reference."""
+    alg, seen = _stub_cgls(monkeypatch, [10.0, 11.0, 11.0, 11.0], niter=6)
+    alg.run_main_iter()
+    assert seen["restarts"] == 2            # entry + one restart, then exit
+    assert np.count_nonzero(alg.l2l[0]) < 6
+
+
+def test_restart_false_preserves_the_early_return(monkeypatch):
+    alg, seen = _stub_cgls(monkeypatch, [10.0, 11.0, 8.0], niter=6, restart=False)
+    alg.run_main_iter()
+    assert seen["restarts"] == 1
+    assert np.count_nonzero(alg.l2l[0]) == 2

--- a/Python/tests/test_krylov_restart_and_norms.py
+++ b/Python/tests/test_krylov_restart_and_norms.py
@@ -153,3 +153,31 @@ def test_im3dnorm_l2_uses_the_same_accumulator():
     # Other norms are untouched.
     y = np.arange(10, dtype=np.float32)
     assert float(im3DNORM(y, 1)) == pytest.approx(float(np.linalg.norm(y, 1)))
+
+
+def test_inner_is_accurate_and_keeps_float32():
+    """Gram-Schmidt coefficients go through inner(); their error compounds
+    across a Krylov basis, so they get the float64 accumulator too."""
+    from tigre.utilities.im3Dnorm import inner
+    n = 50_000_000
+    a = np.full(n, 1e-3, dtype=np.float32)
+    b = np.full(n, 2e-3, dtype=np.float32)
+    exact = n * 2e-6
+    assert float(inner(a, b)) == pytest.approx(exact, rel=1e-5)
+    assert inner(a, b).dtype == np.float32
+    # Shapes are ravelled, so a volume and its flat view agree.
+    v = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    assert float(inner(v, v)) == pytest.approx(float(np.dot(v.ravel(), v.ravel())), rel=1e-6)
+
+
+def test_lsqr_and_lsmr_share_the_restart_fix():
+    """They had the identical single-loop structure and the identical
+    sentinel; a fix that reached only CGLS would leave them stopping at
+    iteration 1."""
+    import inspect
+    for cls_name in ("LSQR", "LSMR", "CGLS"):
+        src = inspect.getsource(getattr(K, cls_name).run_main_iter)
+        assert src.count("while i < self.niter:") == 2, f"{cls_name}: outer loop missing"
+        # The code form, not the docstrings - CGLS's explains the old bug.
+        assert "if self.re_init_at_iteration + 1 == i" not in src, f"{cls_name}: old sentinel"
+        assert "if self.re_init_at_iteration == i" in src, f"{cls_name}: give-up test missing"

--- a/Python/tests/test_krylov_restart_and_norms.py
+++ b/Python/tests/test_krylov_restart_and_norms.py
@@ -35,23 +35,23 @@ def test_norm_is_accurate_where_float32_accumulation_saturates():
     x = np.full(n, 1e-3, dtype=np.float32)
     exact = np.sqrt(n) * 1e-3
 
-    accurate = float(K._norm(x))
+    accurate = float(K.l2norm(x))
     naive = float(np.linalg.norm(x))
     print(f"exact {exact:.6f}  helper {accurate:.6f}  np.linalg.norm {naive:.6f}")
 
     assert accurate == pytest.approx(exact, rel=1e-5)
     # The helper must return float32 so callers' dtypes are unchanged:
     # these scalars multiply float32 volumes and Ax/Atb reject float64.
-    assert K._norm(x).dtype == np.float32
+    assert K.l2norm(x).dtype == np.float32
 
 
 def test_norm_matches_numpy_when_accumulation_is_safe():
     rng = np.random.default_rng(0)
     x = rng.standard_normal(10_000, dtype=np.float32)
-    assert float(K._norm(x)) == pytest.approx(float(np.linalg.norm(x)), rel=1e-6)
+    assert float(K.l2norm(x)) == pytest.approx(float(np.linalg.norm(x)), rel=1e-6)
     # Non-float32 input is passed straight through.
     y = rng.standard_normal(1000)
-    assert float(K._norm(y)) == pytest.approx(float(np.linalg.norm(y)), rel=1e-12)
+    assert float(K.l2norm(y)) == pytest.approx(float(np.linalg.norm(y)), rel=1e-12)
 
 
 def _stub_cgls(monkeypatch, residuals, niter, restart=True):
@@ -96,7 +96,7 @@ def _stub_cgls(monkeypatch, residuals, niter, restart=True):
     def fake_Atb(x, geo, angles, backprojection_type=None, gpuids=None):
         return np.zeros(vol_shape, dtype=np.float32)
 
-    monkeypatch.setattr(K, "_norm", fake_norm)
+    monkeypatch.setattr(K, "l2norm", fake_norm)
     monkeypatch.setattr(K, "Ax", fake_Ax)
     monkeypatch.setattr(K, "Atb", fake_Atb)
     monkeypatch.setattr(K.tigre, "Ax", fake_Ax)
@@ -138,7 +138,7 @@ def test_restart_false_preserves_the_early_return(monkeypatch):
 
 
 def test_im3dnorm_l2_uses_the_same_accumulator():
-    """ASD-POCS reaches the accumulator through im3DNORM, not through _norm.
+    """ASD-POCS reaches the accumulator through im3DNORM, not via the Krylov module.
 
     Its data-fit test and TV step control are ratios of these norms
     (`dd` is projection-sized, `dp`/`dg` volume-sized), so the two entry points
@@ -149,7 +149,7 @@ def test_im3dnorm_l2_uses_the_same_accumulator():
     x = np.full(n, 1e-3, dtype=np.float32)
     exact = np.sqrt(n) * 1e-3
     assert float(im3DNORM(x, 2)) == pytest.approx(exact, rel=1e-5)
-    assert float(K._norm(x)) == pytest.approx(float(l2norm(x)), rel=0)
+    assert K.l2norm is l2norm
     # Other norms are untouched.
     y = np.arange(10, dtype=np.float32)
     assert float(im3DNORM(y, 1)) == pytest.approx(float(np.linalg.norm(y, 1)))

--- a/Python/tests/test_krylov_restart_and_norms.py
+++ b/Python/tests/test_krylov_restart_and_norms.py
@@ -181,3 +181,31 @@ def test_lsqr_and_lsmr_share_the_restart_fix():
         # The code form, not the docstrings - CGLS's explains the old bug.
         assert "if self.re_init_at_iteration + 1 == i" not in src, f"{cls_name}: old sentinel"
         assert "if self.re_init_at_iteration == i" in src, f"{cls_name}: give-up test missing"
+
+
+def test_irn_tv_difference_operator_is_a_true_adjoint_pair():
+    """IRN_TV_CGLS runs CGLS on the stacked operator [A; sqrt(lmbda) W D],
+    which is only meaningful if the transpose it is handed IS the adjoint.
+
+    The original pair was wrong twice over: `Dxx = np.copy(img)` followed by
+    writing only `[0:-2]` left the last two slices holding raw image VALUES
+    instead of differences - so D did not annihilate a constant - and D^T was
+    off by one at index n-2. Measured asymmetry 6.4e-2, and the inner CGLS
+    diverged to 7e5 on a 64^3 phantom.
+    """
+    from tigre.algorithms.krylov_subspace_algorithms import IRN_TV_CGLS
+
+    alg = object.__new__(IRN_TV_CGLS)
+    rng = np.random.default_rng(0)
+    n = 12
+    W = (rng.random((n, n, n)).astype(np.float32) + 0.5)
+    u = rng.standard_normal((n, n, n), dtype=np.float32)
+    v = rng.standard_normal((3, n, n, n), dtype=np.float32)
+
+    lhs = float(np.sum(IRN_TV_CGLS.Lx(alg, W, u) * v))
+    rhs = float(np.sum(u * IRN_TV_CGLS.Ltx(alg, W, v)))
+    assert lhs == pytest.approx(rhs, rel=1e-5), f"<Lu,v>={lhs} vs <u,Ltv>={rhs}"
+
+    # A gradient operator annihilates a constant image, at the boundary too.
+    ones = np.ones((n, n, n), dtype=np.float32)
+    assert np.abs(IRN_TV_CGLS.Lx(alg, ones, ones)).max() == 0.0

--- a/Python/tests/test_krylov_restart_and_norms.py
+++ b/Python/tests/test_krylov_restart_and_norms.py
@@ -135,3 +135,21 @@ def test_restart_false_preserves_the_early_return(monkeypatch):
     alg.run_main_iter()
     assert seen["restarts"] == 1
     assert np.count_nonzero(alg.l2l[0]) == 2
+
+
+def test_im3dnorm_l2_uses_the_same_accumulator():
+    """ASD-POCS reaches the accumulator through im3DNORM, not through _norm.
+
+    Its data-fit test and TV step control are ratios of these norms
+    (`dd` is projection-sized, `dp`/`dg` volume-sized), so the two entry points
+    must not drift apart.
+    """
+    from tigre.utilities.im3Dnorm import im3DNORM, l2norm
+    n = 50_000_000
+    x = np.full(n, 1e-3, dtype=np.float32)
+    exact = np.sqrt(n) * 1e-3
+    assert float(im3DNORM(x, 2)) == pytest.approx(exact, rel=1e-5)
+    assert float(K._norm(x)) == pytest.approx(float(l2norm(x)), rel=0)
+    # Other norms are untouched.
+    y = np.arange(10, dtype=np.float32)
+    assert float(im3DNORM(y, 1)) == pytest.approx(float(np.linalg.norm(y, 1)))

--- a/Python/tests/test_krylov_smoke.py
+++ b/Python/tests/test_krylov_smoke.py
@@ -1,0 +1,85 @@
+"""Every Krylov algorithm reconstructs a small phantom without falling over.
+
+The unit tests beside this file check the arithmetic and the restart control
+flow in isolation. This is the coarse net: run each algorithm end to end and
+require that it finishes, returns finite values, and correlates with the truth
+about as well as FDK does on the same data.
+
+It exists because three defects fixed on 2026-08-24 were all invisible to
+unit tests and all produced plausible-looking output:
+
+  * CGLS / LSQR / LSMR exited after a single iteration on the first residual
+    rise, because the port dropped MATLAB's outer restart loop and the
+    give-up sentinel fired at i == 1;
+  * AB/BA-GMRES, hybrid_LSQR and hybrid_fLSQR_TV returned their result by
+    `return <expr>` - but decorator() discards that and hands back
+    `self.res`, so any early exit silently returned the INITIAL volume
+    (zeros, or with the default FDK warm start an unimproved FDK image);
+  * hybrid_fLSQR_TV never assigned self.res on ANY path, so its output was
+    discarded outright.
+
+Needs a GPU. Small on purpose: 64^3 at 50 views, a few seconds per algorithm.
+"""
+import numpy as np
+import pytest
+
+import tigre
+from tigre.algorithms import (cgls, lsqr, lsmr, ab_gmres, ba_gmres,
+                              hybrid_lsqr, fdk)
+from tigre.algorithms.krylov_subspace_algorithms import CGLS
+
+NITER = 5
+
+
+@pytest.fixture(scope="module")
+def problem():
+    geo = tigre.geometry(mode="cone", nVoxel=np.array([64, 64, 64]), default=True)
+    angles = np.linspace(0, 2 * np.pi, 50, endpoint=False, dtype=np.float32)
+
+    z, y, x = np.mgrid[:64, :64, :64].astype(np.float32)
+    phantom = np.zeros((64, 64, 64), dtype=np.float32)
+    phantom[((x - 30) ** 2 + (y - 32) ** 2 + (z - 32) ** 2) < 14 ** 2] = 1.0
+    phantom[((x - 40) ** 2 + (y - 38) ** 2 + (z - 30) ** 2) < 6 ** 2] = 2.0
+
+    proj = tigre.Ax(phantom, geo, angles)
+    ref = float(np.corrcoef(fdk(proj.copy(), geo, angles).ravel(), phantom.ravel())[0, 1])
+    return geo, angles, phantom, proj, ref
+
+
+@pytest.mark.parametrize("alg", [cgls, lsqr, lsmr, ab_gmres, ba_gmres, hybrid_lsqr])
+def test_algorithm_runs_and_reconstructs(problem, alg):
+    geo, angles, phantom, proj, ref = problem
+    res = alg(proj.copy(), geo, angles, niter=NITER, verbose=False)
+
+    assert res.shape == phantom.shape
+    assert np.isfinite(res).all(), f"{alg.__name__} produced non-finite voxels"
+    assert np.any(res != 0), f"{alg.__name__} returned an all-zero volume"
+
+    r = float(np.corrcoef(res.ravel(), phantom.ravel())[0, 1])
+    # Judged against FDK on the same data rather than an absolute number: this
+    # geometry/phantom pairing is deliberately crude, and FDK itself only
+    # reaches ~0.42 on it. A collapsed reconstruction lands near zero.
+    assert r > 0.6 * ref, f"{alg.__name__} correlates {r:.3f} vs FDK's {ref:.3f}"
+
+
+def test_cgls_does_not_stop_after_one_iteration(problem):
+    """The regression itself: CGLS used to give up at i == 1 and report
+    divergence, leaving 2 of 20 residual slots filled."""
+    geo, angles, phantom, proj, _ = problem
+    geo.check_geo(angles)
+    alg = CGLS(proj.copy(), geo, angles, niter=20, verbose=False)
+    alg.run_main_iter()
+    assert np.count_nonzero(alg.l2l) > 2, (
+        f"CGLS filled only {np.count_nonzero(alg.l2l)} residual slots of 20")
+
+
+def test_no_builtin_sum_over_arrays():
+    """AB/BA-GMRES orthogonalised with Python's builtin sum() over a CT-sized
+    array - element by element, 40x slower than np.dot and less accurate. It
+    is the kind of line that reads as harmless, so guard it."""
+    import inspect
+    from tigre.algorithms import krylov_subspace_algorithms as K
+    src = inspect.getsource(K)
+    offenders = [ln.strip() for ln in src.splitlines()
+                 if "=sum(" in ln.replace(" ", "") and "avgtime" not in ln]
+    assert not offenders, offenders

--- a/Python/tests/test_krylov_smoke.py
+++ b/Python/tests/test_krylov_smoke.py
@@ -16,7 +16,10 @@ unit tests and all produced plausible-looking output:
     `self.res`, so any early exit silently returned the INITIAL volume
     (zeros, or with the default FDK warm start an unimproved FDK image);
   * hybrid_fLSQR_TV never assigned self.res on ANY path, so its output was
-    discarded outright.
+    discarded outright;
+  * IRN_TV_CGLS's difference operator and its "transpose" were not an adjoint
+    pair (6.4e-2 asymmetry) and its inner CGLS had no divergence guard, so it
+    ran to 7e5 on this very phantom.
 
 Needs a GPU. Small on purpose: 64^3 at 50 views, a few seconds per algorithm.
 """
@@ -25,7 +28,7 @@ import pytest
 
 import tigre
 from tigre.algorithms import (cgls, lsqr, lsmr, ab_gmres, ba_gmres,
-                              hybrid_lsqr, fdk)
+                              hybrid_lsqr, irn_tv_cgls, fdk)
 from tigre.algorithms.krylov_subspace_algorithms import CGLS
 
 NITER = 5
@@ -46,7 +49,8 @@ def problem():
     return geo, angles, phantom, proj, ref
 
 
-@pytest.mark.parametrize("alg", [cgls, lsqr, lsmr, ab_gmres, ba_gmres, hybrid_lsqr])
+@pytest.mark.parametrize("alg", [cgls, lsqr, lsmr, ab_gmres, ba_gmres, hybrid_lsqr,
+                                 irn_tv_cgls])
 def test_algorithm_runs_and_reconstructs(problem, alg):
     geo, angles, phantom, proj, ref = problem
     res = alg(proj.copy(), geo, angles, niter=NITER, verbose=False)

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -9,6 +9,7 @@ from tigre.algorithms.iterative_recon_alg import IterativeReconAlg
 from tigre.algorithms.iterative_recon_alg import decorator
 from tigre.utilities.Atb import Atb
 from tigre.utilities.Ax import Ax
+from tigre.utilities.im3Dnorm import l2norm
 import tigre.algorithms as algs
 import scipy.sparse.linalg
 
@@ -21,6 +22,10 @@ else:
 
 def _norm(x, ord=2):
     """Euclidean norm of a large float32 array, accumulated in float64.
+
+    Thin wrapper over ``tigre.utilities.im3Dnorm.l2norm`` so that the Krylov
+    algorithms and the ASD-POCS family - which reaches the same accumulator
+    through ``im3DNORM(..., 2)`` - cannot drift apart.
 
     ``np.linalg.norm`` sums squares in the array's OWN dtype. On a
     projection-sized float32 array the running sum saturates against the tiny
@@ -43,17 +48,9 @@ def _norm(x, ord=2):
     The result is handed back as float32 so that no caller's dtype changes:
     these scalars multiply float32 volumes, and Ax/Atb reject float64.
     """
-    flat = np.ravel(x)
-    if flat.dtype != np.float32:
-        return np.linalg.norm(flat, ord)
     if ord not in (2, None):
-        return np.linalg.norm(flat, ord)
-    total = 0.0
-    step = 1 << 24
-    for k in range(0, flat.size, step):
-        chunk = flat[k:k + step].astype(np.float64)
-        total += float(np.dot(chunk, chunk))
-    return np.float32(np.sqrt(total))
+        return np.linalg.norm(np.ravel(x), ord)
+    return l2norm(x)
 
 
 

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -19,6 +19,44 @@ else:
     default_timer = time.clock
 
 
+def _norm(x, ord=2):
+    """Euclidean norm of a large float32 array, accumulated in float64.
+
+    ``np.linalg.norm`` sums squares in the array's OWN dtype. On a
+    projection-sized float32 array the running sum saturates against the tiny
+    increments still being added to it, and the answer comes back low - badly.
+    Measured against a chunked float64 reference on N(0, 1e-3) data of the
+    shape these algorithms actually see (3072 x 3072 detector):
+
+        45 views  (4.2e8 elements)   0.4 % low
+        180 views (1.7e9 elements)     3 % low
+        360 views (3.4e9 elements)    16 % low
+        720 views (6.8e9 elements)    26 % low
+
+    That is not a reporting detail. Every Krylov step size here is a RATIO of
+    such norms (``alpha = gamma / q_norm**2``), and the loss-of-orthogonality
+    test compares consecutive residual norms, so at production sizes the
+    algorithm both steps wrongly and mistakes accumulator noise for
+    divergence. A 1024^3 volume (1.1e9 elements) is already in the bad regime.
+
+    Accumulating the squares in float64 costs one pass and no full-size copy.
+    The result is handed back as float32 so that no caller's dtype changes:
+    these scalars multiply float32 volumes, and Ax/Atb reject float64.
+    """
+    flat = np.ravel(x)
+    if flat.dtype != np.float32:
+        return np.linalg.norm(flat, ord)
+    if ord not in (2, None):
+        return np.linalg.norm(flat, ord)
+    total = 0.0
+    step = 1 << 24
+    for k in range(0, flat.size, step):
+        chunk = flat[k:k + step].astype(np.float64)
+        total += float(np.dot(chunk, chunk))
+    return np.float32(np.sqrt(total))
+
+
+
 class CGLS(IterativeReconAlg):  # noqa: D101
     __doc__ = (
         " CGLS solves the CBCT problem using the conjugate gradient least\n"
@@ -33,61 +71,84 @@ class CGLS(IterativeReconAlg):  # noqa: D101
         # Don't precompute V and W.
         kwargs.update(dict(W=None, V=None))
         kwargs.update(dict(blocksize=angles.shape[0]))
-        self.re_init_at_iteration = 0
+        # -1, not 0: 0 is a legal iteration index, and the give-up test
+        # compares against it directly.
+        self.re_init_at_iteration = -1
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)
 
     def initialize_algo(self):
         self.__r__ = self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         self.__p__ = Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-        p_norm = np.linalg.norm(self.__p__.ravel(), 2)
+        p_norm = _norm(self.__p__.ravel(), 2)
         self.__gamma__ = p_norm * p_norm
 
     # override
     def run_main_iter(self):
+        """Two nested loops, as in the MATLAB reference (Algorithms/CGLS.m).
 
+        The OUTER loop rebuilds r / p / gamma when orthogonality is lost; the
+        INNER loop iterates. This port previously had only the inner loop, so
+        the `break` that MATLAB uses to fall back into the outer loop and
+        RESTART instead left run_main_iter altogether - CGLS returned after
+        however few iterations preceded the first restart, reporting
+        "exited due to divergence". Combined with a sentinel bug in the
+        give-up test (`re_init_at_iteration + 1 == i` against an initial 0,
+        which is true at i == 1 - MATLAB compares `remember == iter` against
+        an initial 0 that its 1-based counter can never hit on the first
+        check), a single lost step at iteration 1 ended the reconstruction.
+        """
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
 
-        self.initialize_algo()
-        for i in range(self.niter):
-            if self.verbose:
-                self._estimate_time_until_completion(i)
-            if self.Quameasopts is not None:
-                res_prev = copy.deepcopy(self.res)
-
-            avgtic = default_timer()
-            q = tigre.Ax(self.__p__, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-            q_norm = np.linalg.norm(q)
-            alpha = self.__gamma__ / (q_norm * q_norm)
-            self.res += alpha * self.__p__
-            avgtoc = default_timer()
-            avgtime.append(abs(avgtic - avgtoc))
-
-            self.l2l[0, i] = np.linalg.norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
-            if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                self.res -= alpha * self.__p__
-
+        i = 0
+        while i < self.niter:
+            self.initialize_algo()
+            restarted = False
+            while i < self.niter:
                 if self.verbose:
-                    print("re-initilization of CGLS called at iteration:" + str(i))
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("CGLS exited due to divergence.")
-                    return self.res
-                self.re_init_at_iteration=i
-                i=i-1
-                self.initialize_algo()
+                    self._estimate_time_until_completion(i)
+                if self.Quameasopts is not None:
+                    res_prev = copy.deepcopy(self.res)
+
+                avgtic = default_timer()
+                q = tigre.Ax(self.__p__, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
+                q_norm = _norm(q)
+                alpha = self.__gamma__ / (q_norm * q_norm)
+                self.res += alpha * self.__p__
+                avgtoc = default_timer()
+                avgtime.append(abs(avgtic - avgtoc))
+
+                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
+                    # Undo the step that lost orthogonality.
+                    self.res -= alpha * self.__p__
+
+                    if self.verbose:
+                        print("re-initilization of CGLS called at iteration:" + str(i))
+                    # Give up only if the restart itself did not help, i.e.
+                    # this same iteration failed again after a rebuild.
+                    if self.re_init_at_iteration == i or not self.restart:
+                        print("CGLS exited due to divergence.")
+                        return self.res
+                    self.re_init_at_iteration = i
+                    restarted = True
+                    break                 # -> outer loop, retrying this i
+
+                self.__r__ -= alpha * q
+                s = tigre.Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
+                s_norm = _norm(s)
+
+                gamma1 = s_norm * s_norm
+                beta = gamma1 / self.__gamma__
+
+                self.__gamma__ = gamma1
+                self.__p__ = s + beta * self.__p__
+                if self.Quameasopts is not None:
+                    self.error_measurement(res_prev, i)
+                i += 1
+
+            if not restarted:
                 break
-
-            self.__r__ -= alpha * q
-            s = tigre.Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-            s_norm = np.linalg.norm(s)
-
-            gamma1 = s_norm * s_norm
-            beta = gamma1 / self.__gamma__
-
-            self.__gamma__ = gamma1
-            self.__p__ = s + beta * self.__p__
-            if self.Quameasopts is not None:
-                self.error_measurement(res_prev, i)
 
         if self.verbose:
             print(
@@ -120,14 +181,14 @@ class LSQR(IterativeReconAlg):
         # (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
-        normr = np.linalg.norm(self.__u__.ravel(), 2)
+        normr = _norm(self.__u__.ravel(), 2)
         self.__u__ = self.__u__/normr
 
         self.__beta__ = normr
         self.__phibar__ = normr
         self.__v__ = Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
 
-        self.__alpha__ =np.linalg.norm(self.__v__.ravel(), 2)
+        self.__alpha__ =_norm(self.__v__.ravel(), 2)
         self.__v__ = self.__v__/self.__alpha__
         self.__rhobar__ = self.__alpha__
         self.__w__ = np.copy(self.__v__)
@@ -145,12 +206,12 @@ class LSQR(IterativeReconAlg):
             
             #% (3)(a)
             self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-            self.__beta__ = np.linalg.norm(self.__u__.ravel(),2)
+            self.__beta__ = _norm(self.__u__.ravel(),2)
             self.__u__ = self.__u__ / self.__beta__
             
             #% (3)(b)
             self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-            self.__alpha__ = np.linalg.norm(self.__v__.ravel(),2)
+            self.__alpha__ = _norm(self.__v__.ravel(),2)
             self.__v__ = self.__v__ / self.__alpha__    
 
             #% (4)(a-g)
@@ -172,7 +233,7 @@ class LSQR(IterativeReconAlg):
             if self.Quameasopts is not None:
                 self.error_measurement(res_prev, i)
 
-            self.l2l[0, i] = np.linalg.norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 self.res -= (phi / rho) * (self.__v__-self.__w__)/((theta / rho))
                 if self.verbose:
@@ -214,7 +275,7 @@ class hybrid_LSQR(IterativeReconAlg):
         # (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
-        normr = np.linalg.norm(self.__u__.ravel(), 2)
+        normr = _norm(self.__u__.ravel(), 2)
         self.__u__ = self.__u__/normr
         self.__U__[0]=self.__u__.ravel()
 
@@ -242,7 +303,7 @@ class hybrid_LSQR(IterativeReconAlg):
                 v=np.reshape(v.ravel()-(self.__V__[j]*v.ravel())*self.__V__[j],v.shape)
 
    
-            alpha = np.linalg.norm(v.ravel(), 2)
+            alpha = _norm(v.ravel(), 2)
             v = v/alpha
             self.__V__[i] = v.ravel()
 
@@ -253,7 +314,7 @@ class hybrid_LSQR(IterativeReconAlg):
                 self.__u__=np.reshape(self.__u__.ravel()-(self.__U__[j]*self.__u__.ravel())*self.__U__[j],self.__u__.shape)
                 
             
-            self.__beta__  = np.linalg.norm(self.__u__.ravel(), 2)
+            self.__beta__  = _norm(self.__u__.ravel(), 2)
             self.__u__ = self.__u__ / self.__beta__ 
             self.__U__[i+1] = self.__u__.ravel()
 
@@ -282,7 +343,7 @@ class hybrid_LSQR(IterativeReconAlg):
       
 
 
-            self.l2l[0, i] = np.linalg.norm(self.proj - tigre.Ax(self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids))
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 if self.re_init_at_iteration + 1 == i or not self.restart:
                     print("hybrid LSQR exited due to divergence at iteration "+str(i))
@@ -316,12 +377,12 @@ class LSMR(IterativeReconAlg):
         #% Enumeration as given in the paper for 'Algorithm LSMR'
         #% (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        normr = np.linalg.norm(self.__u__.ravel(), 2)
+        normr = _norm(self.__u__.ravel(), 2)
         self.__beta__ = normr
         self.__u__ = self.__u__/normr
 
         self.__v__ = Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-        self.__alpha__ =np.linalg.norm(self.__v__.ravel(), 2)
+        self.__alpha__ =_norm(self.__v__.ravel(), 2)
         self.__v__ = self.__v__/self.__alpha__
 
         self.__alphabar__ = self.__alpha__
@@ -355,11 +416,11 @@ class LSMR(IterativeReconAlg):
                     
             #% (3) Continue the bidiagonalization
             self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-            self.__beta__ = np.linalg.norm(self.__u__.ravel(),2)
+            self.__beta__ = _norm(self.__u__.ravel(),2)
             self.__u__ = self.__u__ / self.__beta__
             
             self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-            self.__alpha__ = np.linalg.norm(self.__v__.ravel(),2)
+            self.__alpha__ = _norm(self.__v__.ravel(),2)
             self.__v__ = self.__v__ / self.__alpha__  
 
             #% (4) Construct and apply rotation \hat{P}_k
@@ -424,7 +485,7 @@ class LSMR(IterativeReconAlg):
             if self.Quameasopts is not None:
                 self.error_measurement(res_prev, i)
 
-            self.l2l[0, i] = np.linalg.norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 self.res -= (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
                 if self.verbose:
@@ -527,7 +588,7 @@ class IRN_TV_CGLS(IterativeReconAlg):
             p_aux_2 = np.sqrt(self.lmbda, dtype=np.float32)*self.Ltx(W, r_aux_2)
             p = p_aux_1 + p_aux_2
             
-            gamma=np.linalg.norm(p.ravel(),2)**2
+            gamma=np.float32(_norm(p.ravel(),2)**2)
 
             for i in range(self.niter):
                 res0=self.res
@@ -536,12 +597,12 @@ class IRN_TV_CGLS(IterativeReconAlg):
 
                 #% q = cat(3, q_aux_1, q_aux_2{1},q_aux_2{2},q_aux_2{3}); % Probably never need to actually do this
                 #% alpha=gamma/norm(q(:),2)^2;
-                alpha=gamma/(np.linalg.norm(q_aux_1.ravel(),2)**2 + np.linalg.norm(q_aux_2[0].ravel(),2)**2 + np.linalg.norm(q_aux_2[1].ravel(),2)**2+np.linalg.norm(q_aux_2[2].ravel(),2)**2)
+                alpha=np.float32(gamma/(_norm(q_aux_1.ravel(),2)**2 + _norm(q_aux_2[0].ravel(),2)**2 + _norm(q_aux_2[1].ravel(),2)**2+_norm(q_aux_2[2].ravel(),2)**2))
                 self.res=self.res+alpha*p
                 aux=self.proj-tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
                 #% residual norm or the original least squares (not Tikhonov).
                 #% Think if that is what we want of the NE residual
-                self.l2l[0, outer*self.niter+i] = np.linalg.norm(aux.ravel(),2)
+                self.l2l[0, outer*self.niter+i] = _norm(aux.ravel(),2)
 
               
                 #% If step is adequate, then continue withg CGLS
@@ -552,8 +613,8 @@ class IRN_TV_CGLS(IterativeReconAlg):
                 s_aux_2 =  np.sqrt(self.lmbda, dtype=np.float32) * self.Ltx(W, r_aux_2)
                 s = s_aux_1 + s_aux_2
 
-                gamma1=np.linalg.norm(s.ravel(),2)**2
-                beta=gamma1/gamma
+                gamma1=np.float32(_norm(s.ravel(),2)**2)
+                beta=np.float32(gamma1/gamma)
                 gamma=gamma1
                 p=s+beta*p
 
@@ -601,7 +662,7 @@ class AB_GMRES(IterativeReconAlg):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         w = np.zeros((self.niter+1,np.prod(self.geo.nDetector)*len(self.angles)),dtype=np.float32)
         r=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        w[0] = r.ravel()/np.linalg.norm(r.ravel(), 2)
+        w[0] = r.ravel()/_norm(r.ravel(), 2)
         h=np.zeros((self.niter,self.niter+1),dtype=np.float32)
         for k in range(self.niter):
             if self.verbose:
@@ -614,11 +675,11 @@ class AB_GMRES(IterativeReconAlg):
                 h[k,i]=sum(qk.ravel()*w[i])
                 qk=qk.ravel()-h[k,i]*w[i]
             
-            h[k,k+1]=np.linalg.norm(qk.ravel(),2)
+            h[k,k+1]=_norm(qk.ravel(),2)
             w[k+1]=qk.ravel()/h[k,k+1]
-            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*np.linalg.norm(r.ravel(),2),rcond=None)
+            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
             y=y[0]
-            self.l2l[0, i] = np.linalg.norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, i] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel(),2)
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 if self.re_init_at_iteration + 1 == i or not self.restart:
                     print("AB-GMRES exited due to divergence at iteration "+str(i))
@@ -664,7 +725,7 @@ class BA_GMRES(IterativeReconAlg):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         w = np.zeros((self.niter+1,(np.prod(self.geo.nVoxel))),dtype=np.float32)
         r=self.backproject(self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids), self.geo, self.angles, gpuids=self.gpuids)
-        w[0] = r.ravel()/np.linalg.norm(r.ravel(), 2)
+        w[0] = r.ravel()/_norm(r.ravel(), 2)
         h=np.zeros((self.niter,self.niter+1),dtype=np.float32)
 
         for k in range(self.niter):
@@ -678,12 +739,12 @@ class BA_GMRES(IterativeReconAlg):
                 h[k,i]=sum(qk.ravel()*w[i])
                 qk=qk.ravel()-h[k,i]*w[i]
             
-            h[k,k+1]=np.linalg.norm(qk.ravel(),2)
+            h[k,k+1]=_norm(qk.ravel(),2)
             w[k+1]=qk.ravel()/h[k,k+1]
-            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*np.linalg.norm(r.ravel(),2),rcond=None)
+            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
             y=y[0]
 
-            self.l2l[0, i] = np.linalg.norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, i] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 if self.re_init_at_iteration + 1 == i or not self.restart:
                     print("BA-GMRES exited due to divergence at iteration "+str(i))
@@ -774,14 +835,14 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
         u=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
         k_aux = Ax(np.ones(self.res.shape,dtype=np.float32)/np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32), self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*np.linalg.norm(k_aux.ravel(),2)**2)*np.dot(k_aux.ravel(),u.ravel())
+        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*np.dot(k_aux.ravel(),u.ravel())
         xA0 =np.ones(self.res.shape,dtype=np.float32)*xA0
-        
-        k_aux = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*np.linalg.norm(k_aux.ravel(),2)**2)*Atb(k_aux, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
+
+        k_aux = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*Atb(k_aux, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
 
         u = u - Ax(xA0, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
 
-        normr=np.linalg.norm(u.ravel(),2)
+        normr=_norm(u.ravel(),2)
         u=u/normr
         self.__U__[0]=u.ravel()
 
@@ -802,7 +863,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
                 self.__T__[i,j] = np.dot(self.__V__[j],v.ravel())
                 v = v.ravel() - self.__T__[i,j]*self.__V__[j]
             v=np.reshape(v,self.res.shape)
-            self.__T__[i,i] = np.linalg.norm(v.ravel(),2)
+            self.__T__[i,i] = _norm(v.ravel(),2)
             v=v/self.__T__[i,i]
 
             z=self.mvT(k_aux,v)
@@ -823,7 +884,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             for j in range(i+1):
                 self.__M__[i,j] = np.dot(self.__U__[j],u.ravel())
                 u = u.ravel() - np.dot(self.__M__[i,j],self.__U__[j])
-            self.__M__[i,i+1]=np.linalg.norm(u.ravel(),2)
+            self.__M__[i,i+1]=_norm(u.ravel(),2)
             u=u/self.__M__[i,i+1]
             u=np.reshape(u,self.proj.shape)
             self.__U__[i+1]=u.ravel()
@@ -848,7 +909,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             d=np.matmul(np.transpose(self.__Z__[0:i+1]),y[0])
             
             x = self.res + np.reshape(d,self.res.shape) + xA0
-            self.l2l[0, i] = np.linalg.norm((self.proj - tigre.Ax(x, self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, i] = _norm((self.proj - tigre.Ax(x, self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 if self.re_init_at_iteration + 1 == i or not self.restart:
                     print("BA-GMRES exited due to divergence at iteration "+str(i))

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -536,53 +536,60 @@ class IRN_TV_CGLS(IterativeReconAlg):
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)
 
     
-    def __build_weights__(self):
-        Dxx=np.copy(self.res)
-        Dyx=np.copy(self.res)
-        Dzx=np.copy(self.res)
+    # The forward difference D and its EXACT adjoint. CGLS is applied to the
+    # stacked operator [A; sqrt(lmbda) W D], and CGLS assumes the transpose it
+    # is handed really is the adjoint - so these two must agree to machine
+    # precision, not approximately.
+    #
+    #   D u[i] = u[i] - u[i+1]  for i <= n-2,   0 at i = n-1
+    #   <Du, y> = sum_{i<=n-2} u[i]y[i] - sum_{j>=1} u[j]y[j-1]
+    #   => (D^T y)[0] = y[0]; [j] = y[j]-y[j-1] for 1<=j<=n-2; [n-1] = -y[n-2]
+    #
+    # The previous pair was wrong on both counts: `Dxx = np.copy(img)` followed
+    # by writing only `[0:-2]` left the LAST TWO slices holding raw image
+    # VALUES rather than differences (so D did not annihilate a constant - it
+    # penalised intensity there), and D^T was off by one at index n-2. Measured
+    # adjoint asymmetry 6.4e-2, which is what made the inner CGLS diverge.
+    def __D__(self, u, axis):
+        out = np.zeros_like(u)
+        a = np.swapaxes(out, 0, axis)
+        b = np.swapaxes(u, 0, axis)
+        a[:-1] = b[:-1] - b[1:]
+        return out
 
-        Dxx[0:-2,:,:]=self.res[0:-2,:,:]-self.res[1:-1,:,:]
-        Dyx[:,0:-2,:]=self.res[:,0:-2,:]-self.res[:,1:-1,:]
-        Dzx[:,:,0:-2]=self.res[:,:,0:-2]-self.res[:,:,1:-1]
- 
-        return (Dxx**2+Dyx**2+Dzx**2+1e-6)**(-1/4)
+    def __Dt__(self, y, axis):
+        out = np.zeros_like(y)
+        a = np.swapaxes(out, 0, axis)
+        b = np.swapaxes(y, 0, axis)
+        a[0] = b[0]
+        a[1:-1] = b[1:-1] - b[0:-2]
+        a[-1] = -b[-2]
+        return out
+
+    def __build_weights__(self):
+        Dxx = self.__D__(self.res, 0)
+        Dyx = self.__D__(self.res, 1)
+        Dzx = self.__D__(self.res, 2)
+        # W^2 = 1/sqrt(|grad u|^2 + eps) is the half-quadratic weight that makes
+        # ||W grad u||^2 a surrogate for the TV seminorm.
+        return (Dxx**2+Dyx**2+Dzx**2+1e-6)**np.float32(-1/4)
 
     def Lx(self,W,img):
-        Dxx=np.copy(img)
-        Dyx=np.copy(img)
-        Dzx=np.copy(img)
-
-        Dxx[0:-2,:,:]=img[0:-2,:,:]-img[1:-1,:,:]
-        Dyx[:,0:-2,:]=img[:,0:-2,:]-img[:,1:-1,:]
-        Dzx[:,:,0:-2]=img[:,:,0:-2]-img[:,:,1:-1]
-
-        return np.stack((W*Dxx,W*Dyx,W*Dzx),axis=0)
+        return np.stack((W*self.__D__(img, 0),
+                         W*self.__D__(img, 1),
+                         W*self.__D__(img, 2)), axis=0)
         
     def Ltx(self,W,img3):
-        Wx_1 = W * img3[0,:,:,:]
-        Wx_2 = W * img3[1,:,:,:]
-        Wx_3 = W * img3[2,:,:,:]
-
-        DxtWx_1=Wx_1
-        DytWx_2=Wx_2
-        DztWx_3=Wx_3
-        
-        DxtWx_1[1:-2,:,:]=Wx_1[1:-2,:,:]-Wx_1[0:-3,:,:]
-        DxtWx_1[-1,:,:]=-Wx_1[-2,:,:]
-        
-        DytWx_2[:,1:-2,:]=Wx_2[:,1:-2,:]-Wx_2[:,0:-3,:]
-        DytWx_2[:,-1,:]=-Wx_2[:,-2,:]
-        
-        DztWx_3[:,:,1:-2]=Wx_3[:,:,1:-2]-Wx_3[:,:,0:-3]
-        DztWx_3[:,:,-1]=-Wx_3[:,:,-2]
-
-        return DxtWx_1 + DytWx_2 + DztWx_3
+        return (self.__Dt__(W * img3[0], 0)
+                + self.__Dt__(W * img3[1], 1)
+                + self.__Dt__(W * img3[2], 2))
 
     def run_main_iter(self):
         self.l2l = np.zeros((1, self.niter*self.niter_outer), dtype=np.float32)
         avgtime = []
 
         res0=self.res
+        best_res = np.float32(np.inf)
    
         for outer in range(self.niter_outer):
             if self.verbose:
@@ -596,7 +603,8 @@ class IRN_TV_CGLS(IterativeReconAlg):
 
 
             W=self.__build_weights__()
-            self.res=res0
+            res_prev_inner = np.float32(np.inf)
+            res_now = np.float32(np.inf)
     
             prox_aux_1 =Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
             prox_aux_2 = self.Lx(W,self.res)*np.sqrt(self.lmbda, dtype=np.float32)
@@ -623,8 +631,29 @@ class IRN_TV_CGLS(IterativeReconAlg):
                 aux=self.proj-tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
                 #% residual norm or the original least squares (not Tikhonov).
                 #% Think if that is what we want of the NE residual
-                self.l2l[0, outer*self.niter+i] = _norm(aux.ravel(),2)
+                step = outer*self.niter+i
+                self.l2l[0, step] = res_now = _norm(aux.ravel(),2)
 
+                # The guard plain CGLS has always had and this loop never did.
+                # In exact arithmetic a CGLS residual cannot rise; when it
+                # does, orthogonality is lost and every later step compounds
+                # it. Left unchecked, niter_outer * niter such steps reach
+                # absurd values - measured mean 8469 / max 5e7 at 512^3, and
+                # 7e5 on a 64^3 phantom where the rise begins at step 2.
+                #
+                # Compare only WITHIN one outer iteration. Across a
+                # reweighting the two residuals belong to different weighted
+                # problems, so a first step that looks worse than the previous
+                # outer's last is not evidence of anything.
+                if i > 0 and res_now > res_prev_inner:
+                    self.res = res0
+                    self.l2l[0, step] = res_prev_inner
+                    res_now = res_prev_inner
+                    if self.verbose:
+                        print("IRN_TV_CGLS: residual rose at outer " + str(outer)
+                              + ", inner " + str(i) + " - reweighting")
+                    break
+                res_prev_inner = res_now
               
                 #% If step is adequate, then continue withg CGLS
                 r_aux_1 = r_aux_1-alpha*q_aux_1
@@ -644,6 +673,15 @@ class IRN_TV_CGLS(IterativeReconAlg):
 
             if self.Quameasopts is not None:
                 self.error_measurement(res_prev, outer)
+
+            # A whole reweighting that improved nothing means the outer
+            # iteration has stalled; more of them will not help.
+            if res_now >= best_res:
+                if self.verbose:
+                    print("IRN_TV_CGLS: reweighting " + str(outer)
+                          + " did not improve the residual - stopping")
+                break
+            best_res = res_now
 
 irn_tv_cgls = decorator(IRN_TV_CGLS, name="irn_tv_cgls")
 

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -9,7 +9,7 @@ from tigre.algorithms.iterative_recon_alg import IterativeReconAlg
 from tigre.algorithms.iterative_recon_alg import decorator
 from tigre.utilities.Atb import Atb
 from tigre.utilities.Ax import Ax
-from tigre.utilities.im3Dnorm import l2norm
+from tigre.utilities.im3Dnorm import l2norm, inner
 import tigre.algorithms as algs
 import scipy.sparse.linalg
 
@@ -168,7 +168,7 @@ class LSQR(IterativeReconAlg):
         # Don't precompute V and W.
         kwargs.update(dict(W=None, V=None))
         kwargs.update(dict(blocksize=angles.shape[0]))
-        self.re_init_at_iteration = 0
+        self.re_init_at_iteration = -1
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)
 
     def initialize_algo(self):
@@ -193,54 +193,64 @@ class LSQR(IterativeReconAlg):
     def run_main_iter(self):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
-        self.initialize_algo()
-        for i in range(self.niter):
-            if self.verbose:
-                self._estimate_time_until_completion(i)
-            if self.Quameasopts is not None:
-                res_prev = copy.deepcopy(self.res)
-            avgtic = default_timer()    
-            
-            #% (3)(a)
-            self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-            self.__beta__ = _norm(self.__u__.ravel(),2)
-            self.__u__ = self.__u__ / self.__beta__
-            
-            #% (3)(b)
-            self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-            self.__alpha__ = _norm(self.__v__.ravel(),2)
-            self.__v__ = self.__v__ / self.__alpha__    
-
-            #% (4)(a-g)
-            rho = np.sqrt(self.__rhobar__**2 + self.__beta__**2)
-            c = self.__rhobar__ / rho
-            s =  self.__beta__ / rho
-            theta = s * self.__alpha__    
-            self.__rhobar__ = - c * self.__alpha__    
-            phi = c * self.__phibar__
-            self.__phibar__ = s * self.__phibar__
-            
-            #% (5) Update x, w
-            self.res = self.res + (phi / rho) * self.__w__
-            self.__w__ = self.__v__ - (theta / rho) * self.__w__
-
-            avgtoc = default_timer()
-            avgtime.append(abs(avgtic - avgtoc))
-
-            if self.Quameasopts is not None:
-                self.error_measurement(res_prev, i)
-
-            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
-            if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                self.res -= (phi / rho) * (self.__v__-self.__w__)/((theta / rho))
+        """Two nested loops, as in the MATLAB reference: the OUTER one rebuilds
+        the Krylov state on a restart, the INNER one iterates. This port had
+        only the inner loop, so the `break` meant to fall back and restart
+        left run_main_iter entirely, and the give-up sentinel fired at i == 1.
+        See CGLS.run_main_iter for the full note."""
+        i = 0
+        while i < self.niter:
+            self.initialize_algo()
+            restarted = False
+            while i < self.niter:
                 if self.verbose:
-                    print("re-initilization of LSQR called at iteration:" + str(i))
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("LSQR exited due to divergence.")
-                    return self.res
-                self.re_init_at_iteration=i
-                i=i-1
-                self.initialize_algo()
+                    self._estimate_time_until_completion(i)
+                if self.Quameasopts is not None:
+                    res_prev = copy.deepcopy(self.res)
+                avgtic = default_timer()    
+            
+                #% (3)(a)
+                self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
+                self.__beta__ = _norm(self.__u__.ravel(),2)
+                self.__u__ = self.__u__ / self.__beta__
+            
+                #% (3)(b)
+                self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
+                self.__alpha__ = _norm(self.__v__.ravel(),2)
+                self.__v__ = self.__v__ / self.__alpha__    
+
+                #% (4)(a-g)
+                rho = np.sqrt(self.__rhobar__**2 + self.__beta__**2)
+                c = self.__rhobar__ / rho
+                s =  self.__beta__ / rho
+                theta = s * self.__alpha__    
+                self.__rhobar__ = - c * self.__alpha__    
+                phi = c * self.__phibar__
+                self.__phibar__ = s * self.__phibar__
+            
+                #% (5) Update x, w
+                self.res = self.res + (phi / rho) * self.__w__
+                self.__w__ = self.__v__ - (theta / rho) * self.__w__
+
+                avgtoc = default_timer()
+                avgtime.append(abs(avgtic - avgtoc))
+
+                if self.Quameasopts is not None:
+                    self.error_measurement(res_prev, i)
+
+                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
+                    self.res -= (phi / rho) * (self.__v__-self.__w__)/((theta / rho))
+                    if self.verbose:
+                        print("re-initilization of LSQR called at iteration:" + str(i))
+                    if self.re_init_at_iteration == i or not self.restart:
+                        print("LSQR exited due to divergence.")
+                        return self.res
+                    self.re_init_at_iteration = i
+                    restarted = True
+                    break                 # -> outer loop, retrying this i
+                i += 1
+            if not restarted:
                 break
 
 lsqr = decorator(LSQR, name="lsqr")
@@ -342,9 +352,13 @@ class hybrid_LSQR(IterativeReconAlg):
 
             self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids))
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("hybrid LSQR exited due to divergence at iteration "+str(i))
-                    return  self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape)
+                # No restart path here, so a genuine rise ends the run. The
+                # old `re_init_at_iteration + 1 == i` test, against a sentinel
+                # this class never reassigns, could only fire at i == 1 and
+                # ignored a rise at every other iteration.
+                print("hybrid LSQR exited due to divergence at iteration "+str(i))
+                self.res = self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape)
+                return self.res
                 
             #% Test for convergence. 
             #% msl: I still need to implement this. 
@@ -366,7 +380,7 @@ class LSMR(IterativeReconAlg):
         # Don't precompute V and W.
         kwargs.update(dict(W=None, V=None))
         kwargs.update(dict(blocksize=angles.shape[0]))
-        self.re_init_at_iteration = 0
+        self.re_init_at_iteration = -1
         IterativeReconAlg.__init__(self, proj, geo, angles, niter, **kwargs)
 
     def initialize_algo(self):
@@ -403,96 +417,106 @@ class LSMR(IterativeReconAlg):
     def run_main_iter(self):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
-        self.initialize_algo()
-        for i in range(self.niter):
-            if self.verbose:
-                self._estimate_time_until_completion(i)
-            if self.Quameasopts is not None:
-                res_prev = copy.deepcopy(self.res)
-            avgtic = default_timer()  
-                    
-            #% (3) Continue the bidiagonalization
-            self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-            self.__beta__ = _norm(self.__u__.ravel(),2)
-            self.__u__ = self.__u__ / self.__beta__
-            
-            self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-            self.__alpha__ = _norm(self.__v__.ravel(),2)
-            self.__v__ = self.__v__ / self.__alpha__  
-
-            #% (4) Construct and apply rotation \hat{P}_k
-            alphahat = np.sqrt(self.__alphabar__**2 + self.lmbda**2)
-            chat = self.__alphabar__/alphahat
-            shat = self.lmbda/alphahat
-
-            #% (5) Construct and apply rotation P_k
-            rhopre = self.__rho__; 
-            self.__rho__ = np.sqrt(alphahat**2 + self.__beta__**2)
-            c = alphahat / self.__rho__
-            s =  self.__beta__ / self.__rho__
-            theta = s * self.__alpha__
-            self.__alphabar__ = c * self.__alpha__
-
-            #% (6) Construct and apply rotation \bar{P}_k
-            thetabar = self.__sbar__  * self.__rho__
-            rhobarpre = self.__rhobar__
-            self.__rhobar__ = np.sqrt((self.__cbar__ *self.__rho__)**2 + theta**2)
-            self.__cbar__ = self.__cbar__ * self.__rho__ / self.__rhobar__
-            self.__sbar__ = theta / self.__rhobar__
-            zetapre = self.__zeta__
-            self.__zeta__ = self.__cbar__ * self.__zetabar__
-            self.__zetabar__ = -self.__sbar__ * self.__zetabar__
-
-            #% (7) Update \bar{h}, x, h
-            self.__hbar__  = self.__h__ - (thetabar*self.__rho__/(rhopre*rhobarpre))*self.__hbar__ 
-            self.res = self.res + (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
-            self.__h__ = self.__v__ - (theta / self.__rho__) * self.__h__
-
-            #% (8) Apply rotation \hat{P}_k, P_k
-            betaacute = chat* self.__betadd__
-            betacheck = - shat* self.__betadd__
-
-            #% Computing ||r_k||
-
-            betahat = c * betaacute
-            betadd = -s * betaacute
-
-            #% Update estimated quantities of interest.
-            #%  (9) If k >= 2, construct and apply \tilde{P} to compute ||r_k||
-            rhotilda = np.sqrt(self.__rhod__**2 + thetabar**2)
-            ctilda = self.__rhod__ / rhotilda
-            stilda = thetabar / rhotilda
-            thetatildapre = self.__thetatilda__
-            self.__thetatilda__ = stilda * self.__rhobar__
-            self.__rhod__ = ctilda * self.__rhobar__
-            #% betatilda = ctilda * betad + stilda * betahat; % msl: in the orinal paper, but not used
-            self.__betad__ = -stilda * self.__betad__ + ctilda * betahat
-
-            #% (10) Update \tilde{t}_k by forward substitution
-            self.__tautilda__ = (zetapre - thetatildapre* self.__tautilda__) / rhotilda
-            taud = (self.__zeta__ - self.__thetatilda__*self.__tautilda__) / self.__rhod__
-            
-            #% (11) Compute ||r_k||
-            self.__d__ = self.__d__ + betacheck**2
-            gamma_var = self.__d__ + (self.__betad__ - taud)**2 + betadd**2
-
-            avgtoc = default_timer()
-            avgtime.append(abs(avgtic - avgtoc))
-
-            if self.Quameasopts is not None:
-                self.error_measurement(res_prev, i)
-
-            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
-            if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                self.res -= (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
+        """Two nested loops, as in the MATLAB reference: the OUTER one rebuilds
+        the Krylov state on a restart, the INNER one iterates. This port had
+        only the inner loop, so the `break` meant to fall back and restart
+        left run_main_iter entirely, and the give-up sentinel fired at i == 1.
+        See CGLS.run_main_iter for the full note."""
+        i = 0
+        while i < self.niter:
+            self.initialize_algo()
+            restarted = False
+            while i < self.niter:
                 if self.verbose:
-                    print("re-initilization of LSMR called at iteration:" + str(i))
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("LSMR exited due to divergence.")
-                    return self.res
-                self.re_init_at_iteration=i
-                i=i-1
-                self.initialize_algo()
+                    self._estimate_time_until_completion(i)
+                if self.Quameasopts is not None:
+                    res_prev = copy.deepcopy(self.res)
+                avgtic = default_timer()  
+                    
+                #% (3) Continue the bidiagonalization
+                self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
+                self.__beta__ = _norm(self.__u__.ravel(),2)
+                self.__u__ = self.__u__ / self.__beta__
+            
+                self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
+                self.__alpha__ = _norm(self.__v__.ravel(),2)
+                self.__v__ = self.__v__ / self.__alpha__  
+
+                #% (4) Construct and apply rotation \hat{P}_k
+                alphahat = np.sqrt(self.__alphabar__**2 + self.lmbda**2)
+                chat = self.__alphabar__/alphahat
+                shat = self.lmbda/alphahat
+
+                #% (5) Construct and apply rotation P_k
+                rhopre = self.__rho__; 
+                self.__rho__ = np.sqrt(alphahat**2 + self.__beta__**2)
+                c = alphahat / self.__rho__
+                s =  self.__beta__ / self.__rho__
+                theta = s * self.__alpha__
+                self.__alphabar__ = c * self.__alpha__
+
+                #% (6) Construct and apply rotation \bar{P}_k
+                thetabar = self.__sbar__  * self.__rho__
+                rhobarpre = self.__rhobar__
+                self.__rhobar__ = np.sqrt((self.__cbar__ *self.__rho__)**2 + theta**2)
+                self.__cbar__ = self.__cbar__ * self.__rho__ / self.__rhobar__
+                self.__sbar__ = theta / self.__rhobar__
+                zetapre = self.__zeta__
+                self.__zeta__ = self.__cbar__ * self.__zetabar__
+                self.__zetabar__ = -self.__sbar__ * self.__zetabar__
+
+                #% (7) Update \bar{h}, x, h
+                self.__hbar__  = self.__h__ - (thetabar*self.__rho__/(rhopre*rhobarpre))*self.__hbar__ 
+                self.res = self.res + (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
+                self.__h__ = self.__v__ - (theta / self.__rho__) * self.__h__
+
+                #% (8) Apply rotation \hat{P}_k, P_k
+                betaacute = chat* self.__betadd__
+                betacheck = - shat* self.__betadd__
+
+                #% Computing ||r_k||
+
+                betahat = c * betaacute
+                betadd = -s * betaacute
+
+                #% Update estimated quantities of interest.
+                #%  (9) If k >= 2, construct and apply \tilde{P} to compute ||r_k||
+                rhotilda = np.sqrt(self.__rhod__**2 + thetabar**2)
+                ctilda = self.__rhod__ / rhotilda
+                stilda = thetabar / rhotilda
+                thetatildapre = self.__thetatilda__
+                self.__thetatilda__ = stilda * self.__rhobar__
+                self.__rhod__ = ctilda * self.__rhobar__
+                #% betatilda = ctilda * betad + stilda * betahat; % msl: in the orinal paper, but not used
+                self.__betad__ = -stilda * self.__betad__ + ctilda * betahat
+
+                #% (10) Update \tilde{t}_k by forward substitution
+                self.__tautilda__ = (zetapre - thetatildapre* self.__tautilda__) / rhotilda
+                taud = (self.__zeta__ - self.__thetatilda__*self.__tautilda__) / self.__rhod__
+            
+                #% (11) Compute ||r_k||
+                self.__d__ = self.__d__ + betacheck**2
+                gamma_var = self.__d__ + (self.__betad__ - taud)**2 + betadd**2
+
+                avgtoc = default_timer()
+                avgtime.append(abs(avgtic - avgtoc))
+
+                if self.Quameasopts is not None:
+                    self.error_measurement(res_prev, i)
+
+                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
+                    self.res -= (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
+                    if self.verbose:
+                        print("re-initilization of LSMR called at iteration:" + str(i))
+                    if self.re_init_at_iteration == i or not self.restart:
+                        print("LSMR exited due to divergence.")
+                        return self.res
+                    self.re_init_at_iteration = i
+                    restarted = True
+                    break                 # -> outer loop, retrying this i
+                i += 1
+            if not restarted:
                 break
 lsmr = decorator(LSMR, name="lsmr")
 
@@ -668,19 +692,25 @@ class AB_GMRES(IterativeReconAlg):
             qk=Ax(self.backproject(np.reshape(w[k],self.proj.shape),self.geo,self.angles,gpuids=self.gpuids),self.geo, self.angles, "Siddon", gpuids=self.gpuids)
             e1=np.zeros(k+2)
             e1[0]=1
+            qk = qk.ravel()
             for i in range(k+1):
-                h[k,i]=sum(qk.ravel()*w[i])
-                qk=qk.ravel()-h[k,i]*w[i]
+                h[k,i]=inner(qk,w[i])
+                qk -= h[k,i]*w[i]
             
-            h[k,k+1]=_norm(qk.ravel(),2)
-            w[k+1]=qk.ravel()/h[k,k+1]
+            h[k,k+1]=_norm(qk,2)
+            w[k+1]=qk/h[k,k+1]
             y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
             y=y[0]
-            self.l2l[0, i] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel(),2)
-            if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("AB-GMRES exited due to divergence at iteration "+str(i))
-                    return  self.__compute_res__(self.res,w[0:k+1],y)
+            self.l2l[0, k] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel(),2)
+            if k > 0 and self.l2l[0, k] > self.l2l[0, k - 1]:
+                # No restart path exists in GMRES here, so a genuine rise ends
+                # the run. It used to be tested as `re_init_at_iteration + 1 ==
+                # i` against a sentinel that is never reassigned, which fired
+                # only when the leaked inner-loop index happened to equal 1 and
+                # did nothing at all for any later iteration.
+                print("AB-GMRES exited due to divergence at iteration "+str(k))
+                self.res = self.__compute_res__(self.res,w[0:k+1],y)
+                return self.res
              
         self.res=self.__compute_res__(self.res,w[0:-1],y)
         return self.res
@@ -732,20 +762,23 @@ class BA_GMRES(IterativeReconAlg):
             qk=self.backproject(Ax(np.reshape(w[k],self.res.shape),self.geo,self.angles, "Siddon",gpuids=self.gpuids),self.geo, self.angles, gpuids=self.gpuids)
             e1=np.zeros(k+2)
             e1[0]=1
+            qk = qk.ravel()
             for i in range(k+1):
-                h[k,i]=sum(qk.ravel()*w[i])
-                qk=qk.ravel()-h[k,i]*w[i]
+                h[k,i]=inner(qk,w[i])
+                qk -= h[k,i]*w[i]
             
-            h[k,k+1]=_norm(qk.ravel(),2)
-            w[k+1]=qk.ravel()/h[k,k+1]
+            h[k,k+1]=_norm(qk,2)
+            w[k+1]=qk/h[k,k+1]
             y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
             y=y[0]
 
-            self.l2l[0, i] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
-            if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("BA-GMRES exited due to divergence at iteration "+str(i))
-                    return  self.__compute_res__(self.res,w[0:k+1],y)
+            self.l2l[0, k] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
+            if k > 0 and self.l2l[0, k] > self.l2l[0, k - 1]:
+                # See the AB-GMRES note: no restart path, and the old sentinel
+                # test could only ever fire at one particular iteration.
+                print("BA-GMRES exited due to divergence at iteration "+str(k))
+                self.res = self.__compute_res__(self.res,w[0:k+1],y)
+                return self.res
              
         self.res=self.__compute_res__(self.res,w[0:-1],y)
         return self.res
@@ -823,7 +856,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
     def mvT(self,k_aux,x ):
             return x.ravel() - k_aux.ravel()*np.sum(x.ravel())
     def mv(self,k_aux,x ):
-            return x.ravel() - np.dot(k_aux.ravel(),x.ravel())
+            return x.ravel() - inner(k_aux,x)
         
     def run_main_iter(self):
         # % Initialise matrices
@@ -832,7 +865,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
         u=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
         k_aux = Ax(np.ones(self.res.shape,dtype=np.float32)/np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32), self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*np.dot(k_aux.ravel(),u.ravel())
+        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*inner(k_aux,u)
         xA0 =np.ones(self.res.shape,dtype=np.float32)*xA0
 
         k_aux = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*Atb(k_aux, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
@@ -857,7 +890,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
                 self._estimate_time_until_completion(i)
             v=Atb(u,self.geo,self.angles,backprojection_type="matched", gpuids=self.gpuids)
             for j in range(i+1):
-                self.__T__[i,j] = np.dot(self.__V__[j],v.ravel())
+                self.__T__[i,j] = inner(self.__V__[j],v)
                 v = v.ravel() - self.__T__[i,j]*self.__V__[j]
             v=np.reshape(v,self.res.shape)
             self.__T__[i,i] = _norm(v.ravel(),2)
@@ -879,7 +912,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             # Update U and projected matrix M
             u = Ax(np.reshape(z,self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids)
             for j in range(i+1):
-                self.__M__[i,j] = np.dot(self.__U__[j],u.ravel())
+                self.__M__[i,j] = inner(self.__U__[j],u)
                 u = u.ravel() - np.dot(self.__M__[i,j],self.__U__[j])
             self.__M__[i,i+1]=_norm(u.ravel(),2)
             u=u/self.__M__[i,i+1]
@@ -902,16 +935,18 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             MZk=np.concatenate((np.transpose(Mk),self.lmbda*ZRksq))
             rhsZk=np.concatenate((rhsk,np.zeros((i+1,1),dtype=np.float32)))
             y = np.linalg.lstsq(MZk, rhsZk,rcond=None)
-            print(y[0])
             d=np.matmul(np.transpose(self.__Z__[0:i+1]),y[0])
             
             x = self.res + np.reshape(d,self.res.shape) + xA0
             self.l2l[0, i] = _norm((self.proj - tigre.Ax(x, self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
-                if self.re_init_at_iteration + 1 == i or not self.restart:
-                    print("BA-GMRES exited due to divergence at iteration "+str(i))
-                    return  x
+                # Same as hybrid_LSQR: no restart path, so stop. (The message
+                # said BA-GMRES; this is hybrid_fLSQR_TV.)
+                print("hybrid fLSQR-TV exited due to divergence at iteration "+str(i))
+                self.res = x
+                return self.res
              
-        return x
+        self.res = x
+        return self.res
 
 hybrid_flsqr_tv = decorator(hybrid_fLSQR_TV, name="hybrid_flsqr_tv")

--- a/Python/tigre/algorithms/krylov_subspace_algorithms.py
+++ b/Python/tigre/algorithms/krylov_subspace_algorithms.py
@@ -20,39 +20,6 @@ else:
     default_timer = time.clock
 
 
-def _norm(x, ord=2):
-    """Euclidean norm of a large float32 array, accumulated in float64.
-
-    Thin wrapper over ``tigre.utilities.im3Dnorm.l2norm`` so that the Krylov
-    algorithms and the ASD-POCS family - which reaches the same accumulator
-    through ``im3DNORM(..., 2)`` - cannot drift apart.
-
-    ``np.linalg.norm`` sums squares in the array's OWN dtype. On a
-    projection-sized float32 array the running sum saturates against the tiny
-    increments still being added to it, and the answer comes back low - badly.
-    Measured against a chunked float64 reference on N(0, 1e-3) data of the
-    shape these algorithms actually see (3072 x 3072 detector):
-
-        45 views  (4.2e8 elements)   0.4 % low
-        180 views (1.7e9 elements)     3 % low
-        360 views (3.4e9 elements)    16 % low
-        720 views (6.8e9 elements)    26 % low
-
-    That is not a reporting detail. Every Krylov step size here is a RATIO of
-    such norms (``alpha = gamma / q_norm**2``), and the loss-of-orthogonality
-    test compares consecutive residual norms, so at production sizes the
-    algorithm both steps wrongly and mistakes accumulator noise for
-    divergence. A 1024^3 volume (1.1e9 elements) is already in the bad regime.
-
-    Accumulating the squares in float64 costs one pass and no full-size copy.
-    The result is handed back as float32 so that no caller's dtype changes:
-    these scalars multiply float32 volumes, and Ax/Atb reject float64.
-    """
-    if ord not in (2, None):
-        return np.linalg.norm(np.ravel(x), ord)
-    return l2norm(x)
-
-
 
 class CGLS(IterativeReconAlg):  # noqa: D101
     __doc__ = (
@@ -76,23 +43,17 @@ class CGLS(IterativeReconAlg):  # noqa: D101
     def initialize_algo(self):
         self.__r__ = self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         self.__p__ = Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-        p_norm = _norm(self.__p__.ravel(), 2)
+        p_norm = l2norm(self.__p__.ravel())
         self.__gamma__ = p_norm * p_norm
 
     # override
     def run_main_iter(self):
         """Two nested loops, as in the MATLAB reference (Algorithms/CGLS.m).
 
-        The OUTER loop rebuilds r / p / gamma when orthogonality is lost; the
-        INNER loop iterates. This port previously had only the inner loop, so
-        the `break` that MATLAB uses to fall back into the outer loop and
-        RESTART instead left run_main_iter altogether - CGLS returned after
-        however few iterations preceded the first restart, reporting
-        "exited due to divergence". Combined with a sentinel bug in the
-        give-up test (`re_init_at_iteration + 1 == i` against an initial 0,
-        which is true at i == 1 - MATLAB compares `remember == iter` against
-        an initial 0 that its 1-based counter can never hit on the first
-        check), a single lost step at iteration 1 ended the reconstruction.
+        The outer loop rebuilds r, p and gamma after a loss of orthogonality
+        (a restart); the inner loop iterates. `re_init_at_iteration` records
+        where the last restart happened, so two restarts in a row stop the
+        algorithm. It starts at -1 because 0 is a valid iteration index.
         """
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
@@ -109,13 +70,13 @@ class CGLS(IterativeReconAlg):  # noqa: D101
 
                 avgtic = default_timer()
                 q = tigre.Ax(self.__p__, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-                q_norm = _norm(q)
+                q_norm = l2norm(q)
                 alpha = self.__gamma__ / (q_norm * q_norm)
                 self.res += alpha * self.__p__
                 avgtoc = default_timer()
                 avgtime.append(abs(avgtic - avgtoc))
 
-                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                self.l2l[0, i] = l2norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
                 if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                     # Undo the step that lost orthogonality.
                     self.res -= alpha * self.__p__
@@ -133,7 +94,7 @@ class CGLS(IterativeReconAlg):  # noqa: D101
 
                 self.__r__ -= alpha * q
                 s = tigre.Atb(self.__r__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-                s_norm = _norm(s)
+                s_norm = l2norm(s)
 
                 gamma1 = s_norm * s_norm
                 beta = gamma1 / self.__gamma__
@@ -178,14 +139,14 @@ class LSQR(IterativeReconAlg):
         # (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
-        normr = _norm(self.__u__.ravel(), 2)
+        normr = l2norm(self.__u__.ravel())
         self.__u__ = self.__u__/normr
 
         self.__beta__ = normr
         self.__phibar__ = normr
         self.__v__ = Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
 
-        self.__alpha__ =_norm(self.__v__.ravel(), 2)
+        self.__alpha__ =l2norm(self.__v__.ravel())
         self.__v__ = self.__v__/self.__alpha__
         self.__rhobar__ = self.__alpha__
         self.__w__ = np.copy(self.__v__)
@@ -193,11 +154,8 @@ class LSQR(IterativeReconAlg):
     def run_main_iter(self):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
-        """Two nested loops, as in the MATLAB reference: the OUTER one rebuilds
-        the Krylov state on a restart, the INNER one iterates. This port had
-        only the inner loop, so the `break` meant to fall back and restart
-        left run_main_iter entirely, and the give-up sentinel fired at i == 1.
-        See CGLS.run_main_iter for the full note."""
+        # Outer loop restarts (rebuilds the Krylov state), inner loop iterates;
+        # see CGLS.run_main_iter.
         i = 0
         while i < self.niter:
             self.initialize_algo()
@@ -211,12 +169,12 @@ class LSQR(IterativeReconAlg):
             
                 #% (3)(a)
                 self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-                self.__beta__ = _norm(self.__u__.ravel(),2)
+                self.__beta__ = l2norm(self.__u__.ravel())
                 self.__u__ = self.__u__ / self.__beta__
             
                 #% (3)(b)
                 self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-                self.__alpha__ = _norm(self.__v__.ravel(),2)
+                self.__alpha__ = l2norm(self.__v__.ravel())
                 self.__v__ = self.__v__ / self.__alpha__    
 
                 #% (4)(a-g)
@@ -238,7 +196,7 @@ class LSQR(IterativeReconAlg):
                 if self.Quameasopts is not None:
                     self.error_measurement(res_prev, i)
 
-                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                self.l2l[0, i] = l2norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
                 if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                     self.res -= (phi / rho) * (self.__v__-self.__w__)/((theta / rho))
                     if self.verbose:
@@ -282,7 +240,7 @@ class hybrid_LSQR(IterativeReconAlg):
         # (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
-        normr = _norm(self.__u__.ravel(), 2)
+        normr = l2norm(self.__u__.ravel())
         self.__u__ = self.__u__/normr
         self.__U__[0]=self.__u__.ravel()
 
@@ -310,7 +268,7 @@ class hybrid_LSQR(IterativeReconAlg):
                 v=np.reshape(v.ravel()-(self.__V__[j]*v.ravel())*self.__V__[j],v.shape)
 
    
-            alpha = _norm(v.ravel(), 2)
+            alpha = l2norm(v.ravel())
             v = v/alpha
             self.__V__[i] = v.ravel()
 
@@ -321,7 +279,7 @@ class hybrid_LSQR(IterativeReconAlg):
                 self.__u__=np.reshape(self.__u__.ravel()-(self.__U__[j]*self.__u__.ravel())*self.__U__[j],self.__u__.shape)
                 
             
-            self.__beta__  = _norm(self.__u__.ravel(), 2)
+            self.__beta__  = l2norm(self.__u__.ravel())
             self.__u__ = self.__u__ / self.__beta__ 
             self.__U__[i+1] = self.__u__.ravel()
 
@@ -350,7 +308,7 @@ class hybrid_LSQR(IterativeReconAlg):
       
 
 
-            self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+            self.l2l[0, i] = l2norm(self.proj - tigre.Ax(self.res + np.reshape(np.matmul(np.transpose(self.__V__[0:i+1]),y),self.res.shape), self.geo, self.angles, "Siddon", gpuids=self.gpuids))
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 # No restart path here, so a genuine rise ends the run. The
                 # old `re_init_at_iteration + 1 == i` test, against a sentinel
@@ -388,12 +346,12 @@ class LSMR(IterativeReconAlg):
         #% Enumeration as given in the paper for 'Algorithm LSMR'
         #% (1) Initialize 
         self.__u__=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        normr = _norm(self.__u__.ravel(), 2)
+        normr = l2norm(self.__u__.ravel())
         self.__beta__ = normr
         self.__u__ = self.__u__/normr
 
         self.__v__ = Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
-        self.__alpha__ =_norm(self.__v__.ravel(), 2)
+        self.__alpha__ =l2norm(self.__v__.ravel())
         self.__v__ = self.__v__/self.__alpha__
 
         self.__alphabar__ = self.__alpha__
@@ -417,11 +375,8 @@ class LSMR(IterativeReconAlg):
     def run_main_iter(self):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         avgtime = []
-        """Two nested loops, as in the MATLAB reference: the OUTER one rebuilds
-        the Krylov state on a restart, the INNER one iterates. This port had
-        only the inner loop, so the `break` meant to fall back and restart
-        left run_main_iter entirely, and the give-up sentinel fired at i == 1.
-        See CGLS.run_main_iter for the full note."""
+        # Outer loop restarts (rebuilds the Krylov state), inner loop iterates;
+        # see CGLS.run_main_iter.
         i = 0
         while i < self.niter:
             self.initialize_algo()
@@ -435,11 +390,11 @@ class LSMR(IterativeReconAlg):
                     
                 #% (3) Continue the bidiagonalization
                 self.__u__ = tigre.Ax(self.__v__, self.geo, self.angles, "Siddon", gpuids=self.gpuids) - self.__alpha__*self.__u__
-                self.__beta__ = _norm(self.__u__.ravel(),2)
+                self.__beta__ = l2norm(self.__u__.ravel())
                 self.__u__ = self.__u__ / self.__beta__
             
                 self.__v__ = tigre.Atb(self.__u__, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids) - self.__beta__*self.__v__
-                self.__alpha__ = _norm(self.__v__.ravel(),2)
+                self.__alpha__ = l2norm(self.__v__.ravel())
                 self.__v__ = self.__v__ / self.__alpha__  
 
                 #% (4) Construct and apply rotation \hat{P}_k
@@ -504,7 +459,7 @@ class LSMR(IterativeReconAlg):
                 if self.Quameasopts is not None:
                     self.error_measurement(res_prev, i)
 
-                self.l2l[0, i] = _norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
+                self.l2l[0, i] = l2norm(self.proj - tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids))
                 if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                     self.res -= (self.__zeta__ / (self.__rho__*self.__rhobar__)) * self.__hbar__ 
                     if self.verbose:
@@ -617,7 +572,7 @@ class IRN_TV_CGLS(IterativeReconAlg):
             p_aux_2 = np.sqrt(self.lmbda, dtype=np.float32)*self.Ltx(W, r_aux_2)
             p = p_aux_1 + p_aux_2
             
-            gamma=np.float32(_norm(p.ravel(),2)**2)
+            gamma=np.float32(l2norm(p.ravel())**2)
 
             for i in range(self.niter):
                 res0=self.res
@@ -626,13 +581,13 @@ class IRN_TV_CGLS(IterativeReconAlg):
 
                 #% q = cat(3, q_aux_1, q_aux_2{1},q_aux_2{2},q_aux_2{3}); % Probably never need to actually do this
                 #% alpha=gamma/norm(q(:),2)^2;
-                alpha=np.float32(gamma/(_norm(q_aux_1.ravel(),2)**2 + _norm(q_aux_2[0].ravel(),2)**2 + _norm(q_aux_2[1].ravel(),2)**2+_norm(q_aux_2[2].ravel(),2)**2))
+                alpha=np.float32(gamma/(l2norm(q_aux_1.ravel())**2 + l2norm(q_aux_2[0].ravel())**2 + l2norm(q_aux_2[1].ravel())**2+l2norm(q_aux_2[2].ravel())**2))
                 self.res=self.res+alpha*p
                 aux=self.proj-tigre.Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
                 #% residual norm or the original least squares (not Tikhonov).
                 #% Think if that is what we want of the NE residual
                 step = outer*self.niter+i
-                self.l2l[0, step] = res_now = _norm(aux.ravel(),2)
+                self.l2l[0, step] = res_now = l2norm(aux.ravel())
 
                 # The guard plain CGLS has always had and this loop never did.
                 # In exact arithmetic a CGLS residual cannot rise; when it
@@ -663,7 +618,7 @@ class IRN_TV_CGLS(IterativeReconAlg):
                 s_aux_2 =  np.sqrt(self.lmbda, dtype=np.float32) * self.Ltx(W, r_aux_2)
                 s = s_aux_1 + s_aux_2
 
-                gamma1=np.float32(_norm(s.ravel(),2)**2)
+                gamma1=np.float32(l2norm(s.ravel())**2)
                 beta=np.float32(gamma1/gamma)
                 gamma=gamma1
                 p=s+beta*p
@@ -721,7 +676,7 @@ class AB_GMRES(IterativeReconAlg):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         w = np.zeros((self.niter+1,np.prod(self.geo.nDetector)*len(self.angles)),dtype=np.float32)
         r=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        w[0] = r.ravel()/_norm(r.ravel(), 2)
+        w[0] = r.ravel()/l2norm(r.ravel())
         h=np.zeros((self.niter,self.niter+1),dtype=np.float32)
         for k in range(self.niter):
             if self.verbose:
@@ -735,11 +690,11 @@ class AB_GMRES(IterativeReconAlg):
                 h[k,i]=inner(qk,w[i])
                 qk -= h[k,i]*w[i]
             
-            h[k,k+1]=_norm(qk,2)
+            h[k,k+1]=l2norm(qk)
             w[k+1]=qk/h[k,k+1]
-            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
+            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*l2norm(r.ravel()),rcond=None)
             y=y[0]
-            self.l2l[0, k] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, k] = l2norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y),self.geo,self.angles, "Siddon",gpuids=self.gpuids)).ravel())
             if k > 0 and self.l2l[0, k] > self.l2l[0, k - 1]:
                 # No restart path exists in GMRES here, so a genuine rise ends
                 # the run. It used to be tested as `re_init_at_iteration + 1 ==
@@ -790,7 +745,7 @@ class BA_GMRES(IterativeReconAlg):
         self.l2l = np.zeros((1, self.niter), dtype=np.float32)
         w = np.zeros((self.niter+1,(np.prod(self.geo.nVoxel))),dtype=np.float32)
         r=self.backproject(self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids), self.geo, self.angles, gpuids=self.gpuids)
-        w[0] = r.ravel()/_norm(r.ravel(), 2)
+        w[0] = r.ravel()/l2norm(r.ravel())
         h=np.zeros((self.niter,self.niter+1),dtype=np.float32)
 
         for k in range(self.niter):
@@ -805,12 +760,12 @@ class BA_GMRES(IterativeReconAlg):
                 h[k,i]=inner(qk,w[i])
                 qk -= h[k,i]*w[i]
             
-            h[k,k+1]=_norm(qk,2)
+            h[k,k+1]=l2norm(qk)
             w[k+1]=qk/h[k,k+1]
-            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*_norm(r.ravel(),2),rcond=None)
+            y=np.linalg.lstsq(np.transpose(h[0:k+1,0:k+2]),e1*l2norm(r.ravel()),rcond=None)
             y=y[0]
 
-            self.l2l[0, k] = _norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, k] = l2norm((self.proj - tigre.Ax(self.__compute_res__(self.res,w[0:k+1],y), self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel())
             if k > 0 and self.l2l[0, k] > self.l2l[0, k - 1]:
                 # See the AB-GMRES note: no restart path, and the old sentinel
                 # test could only ever fire at one particular iteration.
@@ -903,14 +858,14 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
         u=self.proj - Ax(self.res, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
         
         k_aux = Ax(np.ones(self.res.shape,dtype=np.float32)/np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32), self.geo, self.angles, "Siddon", gpuids=self.gpuids)
-        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*inner(k_aux,u)
+        xA0 = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*l2norm(k_aux.ravel())**2)*inner(k_aux,u)
         xA0 =np.ones(self.res.shape,dtype=np.float32)*xA0
 
-        k_aux = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*_norm(k_aux.ravel(),2)**2)*Atb(k_aux, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
+        k_aux = 1/(np.sqrt(np.prod(self.geo.nVoxel), dtype=np.float32)*l2norm(k_aux.ravel())**2)*Atb(k_aux, self.geo, self.angles, backprojection_type="matched", gpuids=self.gpuids)
 
         u = u - Ax(xA0, self.geo, self.angles, "Siddon", gpuids=self.gpuids)
 
-        normr=_norm(u.ravel(),2)
+        normr=l2norm(u.ravel())
         u=u/normr
         self.__U__[0]=u.ravel()
 
@@ -931,7 +886,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
                 self.__T__[i,j] = inner(self.__V__[j],v)
                 v = v.ravel() - self.__T__[i,j]*self.__V__[j]
             v=np.reshape(v,self.res.shape)
-            self.__T__[i,i] = _norm(v.ravel(),2)
+            self.__T__[i,i] = l2norm(v.ravel())
             v=v/self.__T__[i,i]
 
             z=self.mvT(k_aux,v)
@@ -952,7 +907,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             for j in range(i+1):
                 self.__M__[i,j] = inner(self.__U__[j],u)
                 u = u.ravel() - np.dot(self.__M__[i,j],self.__U__[j])
-            self.__M__[i,i+1]=_norm(u.ravel(),2)
+            self.__M__[i,i+1]=l2norm(u.ravel())
             u=u/self.__M__[i,i+1]
             u=np.reshape(u,self.proj.shape)
             self.__U__[i+1]=u.ravel()
@@ -976,7 +931,7 @@ class hybrid_fLSQR_TV(IterativeReconAlg):
             d=np.matmul(np.transpose(self.__Z__[0:i+1]),y[0])
             
             x = self.res + np.reshape(d,self.res.shape) + xA0
-            self.l2l[0, i] = _norm((self.proj - tigre.Ax(x, self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel(),2)
+            self.l2l[0, i] = l2norm((self.proj - tigre.Ax(x, self.geo, self.angles, "Siddon", gpuids=self.gpuids)).ravel())
             if i > 0 and self.l2l[0, i] > self.l2l[0, i - 1]:
                 # Same as hybrid_LSQR: no restart path, so stop. (The message
                 # said BA-GMRES; this is hybrid_fLSQR_TV.)

--- a/Python/tigre/algorithms/pocs_algorithms.py
+++ b/Python/tigre/algorithms/pocs_algorithms.py
@@ -7,7 +7,7 @@ from tigre.algorithms.iterative_recon_alg import IterativeReconAlg
 from tigre.algorithms.iterative_recon_alg import decorator
 from tigre.algorithms.single_pass_algorithms import FDK
 from tigre.utilities.Ax import Ax
-from tigre.utilities.im3Dnorm import im3DNORM
+from tigre.utilities.im3Dnorm import im3DNORM, inner
 
 
 
@@ -364,7 +364,7 @@ class initPICCS(IterativeReconAlg):
             # the decay on a float copy nobody reads, so lambda_red had no effect on
             # the solver at all. Keep them in step.
             self.lmbda = self.beta
-            c = np.dot(dg_vec.reshape(-1,), dp_vec.reshape(-1,)) / max(
+            c = inner(dg_vec, dp_vec) / max(
                 dg * dp, 1e-6
             )  # reshape ensures no copy is made.
             if (c < -0.99 and dd <= self.epsilon) or self.beta < 0.005 or n_iter >= self.niter:
@@ -608,7 +608,7 @@ class initPCSD(IterativeReconAlg):
             # the decay on a float copy nobody reads, so lambda_red had no effect on
             # the solver at all. Keep them in step.
             self.lmbda = self.beta
-            c = np.dot(dg_vec.reshape(-1,), dp_vec.reshape(-1,)) / max(dg * dp, 1e-6) # reshape ensures no copy is made. 
+            c = inner(dg_vec, dp_vec) / max(dg * dp, 1e-6) # reshape ensures no copy is made. 
             if (c < -0.99 and dd <=
                     self.epsilon) or self.beta < 0.005 or n_iter > self.niter:
                 if self.verbose:

--- a/Python/tigre/utilities/im3Dnorm.py
+++ b/Python/tigre/utilities/im3Dnorm.py
@@ -14,11 +14,22 @@ def l2norm(x, chunk=1 << 24):
         360 views (3.4e9 elements)    16 % low
         720 views (6.8e9 elements)    26 % low
 
-    A 1024^3 volume (1.1e9 elements) is already ~1 % low. These norms are not
+    A 1024^3 volume (1.1e9 elements) is 1.4 % low. These norms are not
     only reported - they drive step sizes and stopping rules (CGLS's
     ``alpha = gamma / q_norm**2``; the ASD-POCS data-fit and TV-step control),
     so at production sizes the algorithms misbehave rather than merely
     mis-report.
+
+    Two properties of the failure are worth knowing. It is driven by the
+    ACCUMULATOR growing against terms that stay small - a sum of squares is
+    all-positive, so nothing ever cancels - rather than by N alone. And it is
+    BLAS-dependent: the figures above are scipy-openblas 0.3.31 on the Linux
+    box where the production runs happen; the same sizes on this project's
+    Windows BLAS are ~76x more accurate. Do not assume a platform is safe.
+
+    ``np.sum`` is NOT affected - numpy's own pairwise summation gives 4e-9 at
+    1024^3 - so `np.sum(x * x)` was never the problem and does not need this.
+    Only reductions that dispatch to BLAS (``np.dot``, ``np.linalg.norm``) do.
 
     One pass, no full-size copy. Returns float32 so no caller's dtype changes:
     these scalars multiply float32 volumes, and Ax/Atb reject float64.
@@ -31,6 +42,28 @@ def l2norm(x, chunk=1 << 24):
         c = flat[k:k + chunk].astype(np.float64)
         total += float(np.dot(c, c))
     return np.float32(np.sqrt(total))
+
+
+def inner(a, b, chunk=1 << 24):
+    """Inner product of two float32 arrays, accumulated in float64.
+
+    Same reasoning as l2norm, one step weaker: a dot of two DIFFERENT vectors
+    has cancelling signs, so its accumulator does not grow monotonically and
+    BLAS holds up better - measured 7.8e-5 relative error at 1024^3 against
+    l2norm's 1.4e-2 for the sum of squares. Still four orders worse than a
+    float64 accumulation, and these products are Gram-Schmidt coefficients
+    whose error compounds across a Krylov basis, so they use it too.
+
+    Returns float32, like l2norm, so no caller's dtype changes.
+    """
+    fa, fb = np.ravel(a), np.ravel(b)
+    if fa.dtype != np.float32 or fb.dtype != np.float32:
+        return np.dot(fa, fb)
+    total = 0.0
+    for k in range(0, fa.size, chunk):
+        total += float(np.dot(fa[k:k + chunk].astype(np.float64),
+                              fb[k:k + chunk].astype(np.float64)))
+    return np.float32(total)
 
 
 def im3DNORM(img, normind, varargin=None):

--- a/Python/tigre/utilities/im3Dnorm.py
+++ b/Python/tigre/utilities/im3Dnorm.py
@@ -4,7 +4,8 @@ import numpy as np
 def l2norm(x, chunk=1 << 24):
     """Euclidean norm of a float32 array, accumulated in float64.
 
-    ``np.linalg.norm`` sums the squares in the array's OWN dtype. 
+    ``np.linalg.norm`` sums the squares in the array's own dtype, so on large
+    float32 arrays the result comes back low.
 
     One pass, no full-size copy. Returns float32 so no caller's dtype changes:
     these scalars multiply float32 volumes, and Ax/Atb reject float64.
@@ -22,7 +23,7 @@ def l2norm(x, chunk=1 << 24):
 def inner(a, b, chunk=1 << 24):
     """Inner product of two float32 arrays, accumulated in float64.
 
-       Returns float32, like l2norm, so no caller's dtype changes.
+    Returns float32, like l2norm, so no caller's dtype changes.
     """
     fa, fb = np.ravel(a), np.ravel(b)
     if fa.dtype != np.float32 or fb.dtype != np.float32:

--- a/Python/tigre/utilities/im3Dnorm.py
+++ b/Python/tigre/utilities/im3Dnorm.py
@@ -1,6 +1,38 @@
 import numpy as np
 
 
+def l2norm(x, chunk=1 << 24):
+    """Euclidean norm of a float32 array, accumulated in float64.
+
+    ``np.linalg.norm`` sums the squares in the array's OWN dtype. On the arrays
+    this toolbox actually handles that is not survivable: the running total
+    dwarfs the increments still being added to it and the answer comes back
+    LOW. Measured against a chunked float64 reference, on a 3072^2 detector:
+
+        45 views  (4.2e8 elements)   0.4 % low
+        180 views (1.7e9 elements)     3 % low
+        360 views (3.4e9 elements)    16 % low
+        720 views (6.8e9 elements)    26 % low
+
+    A 1024^3 volume (1.1e9 elements) is already ~1 % low. These norms are not
+    only reported - they drive step sizes and stopping rules (CGLS's
+    ``alpha = gamma / q_norm**2``; the ASD-POCS data-fit and TV-step control),
+    so at production sizes the algorithms misbehave rather than merely
+    mis-report.
+
+    One pass, no full-size copy. Returns float32 so no caller's dtype changes:
+    these scalars multiply float32 volumes, and Ax/Atb reject float64.
+    """
+    flat = np.ravel(x)
+    if flat.dtype != np.float32:
+        return np.linalg.norm(flat, 2)
+    total = 0.0
+    for k in range(0, flat.size, chunk):
+        c = flat[k:k + chunk].astype(np.float64)
+        total += float(np.dot(c, c))
+    return np.float32(np.sqrt(total))
+
+
 def im3DNORM(img, normind, varargin=None):
     """
     % IMAGE3DNORM computes the desired image norm
@@ -32,6 +64,10 @@ def im3DNORM(img, normind, varargin=None):
     if normind is [np.inf, -np.inf, "fro", "nuc"]:
         return np.linalg.norm(img.ravel(), normind)
     if type(normind) is int:
+        # The L2 case is the one every caller in this toolbox uses, and the one
+        # a float32 accumulator cannot compute at these sizes - see l2norm.
+        if normind == 2:
+            return l2norm(img)
         return np.linalg.norm(img.ravel(), normind)
     if normind == "TV":
         gx, gy, gz = np.diff(img, axis=2), np.diff(img, axis=1), np.diff(img, axis=0)

--- a/Python/tigre/utilities/im3Dnorm.py
+++ b/Python/tigre/utilities/im3Dnorm.py
@@ -4,32 +4,7 @@ import numpy as np
 def l2norm(x, chunk=1 << 24):
     """Euclidean norm of a float32 array, accumulated in float64.
 
-    ``np.linalg.norm`` sums the squares in the array's OWN dtype. On the arrays
-    this toolbox actually handles that is not survivable: the running total
-    dwarfs the increments still being added to it and the answer comes back
-    LOW. Measured against a chunked float64 reference, on a 3072^2 detector:
-
-        45 views  (4.2e8 elements)   0.4 % low
-        180 views (1.7e9 elements)     3 % low
-        360 views (3.4e9 elements)    16 % low
-        720 views (6.8e9 elements)    26 % low
-
-    A 1024^3 volume (1.1e9 elements) is 1.4 % low. These norms are not
-    only reported - they drive step sizes and stopping rules (CGLS's
-    ``alpha = gamma / q_norm**2``; the ASD-POCS data-fit and TV-step control),
-    so at production sizes the algorithms misbehave rather than merely
-    mis-report.
-
-    Two properties of the failure are worth knowing. It is driven by the
-    ACCUMULATOR growing against terms that stay small - a sum of squares is
-    all-positive, so nothing ever cancels - rather than by N alone. And it is
-    BLAS-dependent: the figures above are scipy-openblas 0.3.31 on the Linux
-    box where the production runs happen; the same sizes on this project's
-    Windows BLAS are ~76x more accurate. Do not assume a platform is safe.
-
-    ``np.sum`` is NOT affected - numpy's own pairwise summation gives 4e-9 at
-    1024^3 - so `np.sum(x * x)` was never the problem and does not need this.
-    Only reductions that dispatch to BLAS (``np.dot``, ``np.linalg.norm``) do.
+    ``np.linalg.norm`` sums the squares in the array's OWN dtype. 
 
     One pass, no full-size copy. Returns float32 so no caller's dtype changes:
     these scalars multiply float32 volumes, and Ax/Atb reject float64.

--- a/Python/tigre/utilities/im3Dnorm.py
+++ b/Python/tigre/utilities/im3Dnorm.py
@@ -22,14 +22,7 @@ def l2norm(x, chunk=1 << 24):
 def inner(a, b, chunk=1 << 24):
     """Inner product of two float32 arrays, accumulated in float64.
 
-    Same reasoning as l2norm, one step weaker: a dot of two DIFFERENT vectors
-    has cancelling signs, so its accumulator does not grow monotonically and
-    BLAS holds up better - measured 7.8e-5 relative error at 1024^3 against
-    l2norm's 1.4e-2 for the sum of squares. Still four orders worse than a
-    float64 accumulation, and these products are Gram-Schmidt coefficients
-    whose error compounds across a Krylov basis, so they use it too.
-
-    Returns float32, like l2norm, so no caller's dtype changes.
+       Returns float32, like l2norm, so no caller's dtype changes.
     """
     fa, fb = np.ravel(a), np.ravel(b)
     if fa.dtype != np.float32 or fb.dtype != np.float32:

--- a/Python/tigre/utilities/power_method.py
+++ b/Python/tigre/utilities/power_method.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import numpy as np
 import tigre
+from tigre.utilities.im3Dnorm import l2norm
 
 
 def svd_power_method(arr, geo, angles, **kwargs):
@@ -52,12 +53,17 @@ def svd_power_method(arr, geo, angles, **kwargs):
                 print("error for val is:" + str(error))
         # very verbose and inefficient for now
         omega = tigre.Ax(arr_old, geo, angles)
-        alpha = np.linalg.norm(omega)
+        alpha = l2norm(omega)
         u = (1.0 / alpha) * omega
-        z = tigre.Atb(u, geo, angles)
-        beta = np.linalg.norm(z)
+        # sigma_max(A) needs A^T: the "matched" backprojector is the (near-)
+        # adjoint of Ax (inner-product test: ~4e-5 relative asymmetry). The
+        # previous call used Atb's default "FDK"-weighted backprojector,
+        # which is NOT A^T (~93% inner-product discrepancy) - any Lipschitz/
+        # step-size estimate built on it is for the wrong operator.
+        z = tigre.Atb(u, geo, angles, backprojection_type="matched")
+        beta = l2norm(z)
         arr = (1.0 / beta) * z
-        error = np.linalg.norm(tigre.Ax(arr, geo, angles) - beta * u)
+        error = l2norm(tigre.Ax(arr, geo, angles) - beta * u)
         sigma = beta
         arr_old = arr
         i += 1


### PR DESCRIPTION
Four commits, each self-contained and independently checkable; together they
make CGLS/LSQR/LSMR/hybrid_LSQR/AB-GMRES/BA-GMRES/hybrid_fLSQR_TV/IRN_TV_CGLS
behave at production sizes. No CUDA or `.pyx` changes — pure Python, no
rebuild. No new dependencies.

## 1. A float32 `np.linalg.norm` cannot measure a production-sized residual

`np.linalg.norm` accumulates the sum of squares in the array's OWN dtype. On a
projection-sized float32 array the running sum saturates against the
increments still being added, and the answer comes back low. Measured against
a chunked float64 reference on N(0, 1e-3) data at a 3072×3072 detector:

| views | elements | `np.linalg.norm` error |
|---|---|---|
| 45 | 4.2e8 | 0.4 % low |
| 180 | 1.7e9 | 3 % low |
| 360 | 3.4e9 | 16 % low |
| 720 | 6.8e9 | **26 % low** |

A 1024³ volume (1.1e9 elements) is already ~1.4 % off. This is not a
reporting detail: every Krylov step size is a RATIO of such norms
(`alpha = gamma / q_norm**2`), and the loss-of-orthogonality test compares
consecutive residual norms — so at production sizes CGLS both steps wrongly
(volume-norm ÷ projection-norm: the two biases do not cancel) and mistakes
accumulator noise for divergence. On a real 720-view / 1024³ dataset CGLS
"exited due to divergence" at iteration 1; with this change it runs to
completion and its mean lands in family with the other iterative methods.

Two things decide severity, both worth knowing: a **sum of squares** is far
worse than a dot of two different vectors (nothing cancels), and the bias is
**BLAS-dependent** (the same sizes under a different BLAS were ~76× more
accurate), so it can look absent on one machine and be 26 % on another.

Fix: `tigre.utilities.im3Dnorm` gains `l2norm()` and `inner()` that accumulate
in float64 and **return float32**, so no caller's dtype changes (Ax/Atb reject
float64). Routed through them: every Krylov norm, `im3DNORM(...,2)` (so the
ASD-POCS family gets it too), `svd_power_method` (this IS FISTA's Lipschitz
constant) and the POCS TV-step cosine.

## 2. The CGLS/LSQR/LSMR restart never restarted

MATLAB's `CGLS.m` breaks out of an INNER loop into an OUTER one that rebuilds
r/p/gamma. The Python port kept only the inner loop, so that `break` left
`run_main_iter` altogether — the method returned after however few iterations
preceded the first restart. Its give-up sentinel also read
`re_init_at_iteration + 1 == i` against an initial 0, which is true at
`i == 1`. One lost step at iteration 1 ended the reconstruction. LSQR and LSMR
had the identical structure. All three now have the two-loop form and a `-1`
sentinel.

hybrid_LSQR, hybrid_fLSQR_TV and AB/BA-GMRES have no restart path at all — their
sentinel could only fire at one iteration and ignored a rise at every other —
so they now simply stop on a genuine rise.

## 3. Three algorithms discarded their result

`decorator()` ignores what `run_main_iter` RETURNS and hands back `self.res`.
Any `return <expr>` that does not first assign `self.res` therefore returns the
INITIAL volume — zeros, or with an FDK warm start an unimproved FDK image that
looks entirely plausible. `ba_gmres` and `hybrid_lsqr` returned all-zero
volumes on every early exit; **`hybrid_fLSQR_TV` never assigned `self.res` on
any path**, so its output was discarded always.

## 4. AB/BA-GMRES orthogonalised with Python's builtin `sum()`

`h[k,i] = sum(qk.ravel()*w[i])` iterates a CT-sized array element by element:
~40× slower than `np.dot`, 800× less accurate. BA_GMRES's basis is
volume-space → ~107 s per coefficient × 210 coefficients at niter 20; on a
real 1024³ problem that was most of a 4.1 h run (41.6 min after this change).

## 5. IRN_TV_CGLS: an operator that was not an adjoint, and no divergence guard

CGLS runs on the stacked operator `[A; √λ·W·D]` and assumes the handed
transpose IS the adjoint. `Lx`/`Ltx` had an inner-product asymmetry of
**6.4e-2**: `Dxx = np.copy(img)` then writing only `[0:-2]` left the last two
slices holding raw image VALUES (so `D(constant) ≠ 0` — a Tikhonov term
smuggled into part of the volume), and `Dᵀ` was off by one at n-2. Plus no
inner divergence guard (plain CGLS has one): the residual rose from step 2 and
compounded 9.7e3 → 6.9e5. The guard compares only WITHIN one outer iteration —
across a reweighting the residuals belong to different weighted problems. On a
64³ phantom (FDK correlation 0.4163): λ=1 → 0.142 before, **0.4264** after;
λ=100 → 0.451 before, **0.4697** after.

## Tests

- `Python/tests/test_krylov_restart_and_norms.py` (no GPU): float64 accumulation
  vs a chunked reference, float32 return type, restart re-entry and sentinel,
  the D/Dᵀ adjoint, the ordering of `sum()` vs `np.dot`.
- `Python/tests/test_krylov_smoke.py` (GPU): every Krylov method runs, returns a
  finite non-zero volume and improves on its warm start.

Verified on Windows (RTX A6000, CUDA 13.3) against current master. Merge
conflicts with #770 are expected to be trivial (#770 changes 3 lines of
IRN_TV_CGLS scalar dtypes; this branch keeps upstream's `np.sqrt(...,
dtype=np.float32)` form for those lines).
